### PR TITLE
removed unnecessary check

### DIFF
--- a/behaviors/services/transaction-pool.md
+++ b/behaviors/services/transaction-pool.md
@@ -111,7 +111,6 @@ Currently a single instance per virtual chain per node.
   * Sender virtual chain matches contract virtual chain and matches the transaction pool's virtual chain.
   * Check transaction timestamp, accept only transactions that haven't expired.
     * Transaction is expired if its timestamp is earlier than current time minus the [configurable](../config/shared.md) expiration window (eg. 30 min).
-* Transaction wasn't already committed (exist in the committed pool).
 * Verify pre order checks (like signature and subscription) for all transactions by calling `VirtualMachine.TransactionSetPreOrder`.
   * Remove invalid transactions, include only transactions that are valid for pre-order.
   


### PR DESCRIPTION
> Transaction wasn't already committed (exist in the committed pool).
This can never happen, as the same thread that calls `GetTransactionsForOrdering` also calls `CommitTransactionReceipts` which should move transactions from pending pool to committed pool. A transaction can never be in both pools, and a race condition cannot happen in this case.