### PR TITLE
Go ctx

### DIFF
--- a/types/build.sh
+++ b/types/build.sh
@@ -6,7 +6,7 @@ cp -r ../interfaces/* ./go
 
 ### OLD: (uses brew) membufc --go --mock `find . -name "*.proto"`
 ### NEW: running membufc directly from source to avoid waiting for brew releases
-go run $(ls -1 ../../membuffers/go/membufc/*.go | grep -v _test.go) --go --mock `find . -name "*.proto"`
+go run $(ls -1 ../../membuffers/go/membufc/*.go | grep -v _test.go) --go --mock --go-ctx `find . -name "*.proto"`
 rm `find . -name "*.proto"`
 
 echo ""

--- a/types/go/primitives/crypto.mb.go
+++ b/types/go/primitives/crypto.mb.go
@@ -1,4 +1,4 @@
-// AUTO GENERATED FILE (by membufc proto compiler v0.0.19)
+// AUTO GENERATED FILE (by membufc proto compiler v0.0.20)
 package primitives
 
 import (

--- a/types/go/primitives/integers.mb.go
+++ b/types/go/primitives/integers.mb.go
@@ -1,4 +1,4 @@
-// AUTO GENERATED FILE (by membufc proto compiler v0.0.19)
+// AUTO GENERATED FILE (by membufc proto compiler v0.0.20)
 package primitives
 
 import (

--- a/types/go/primitives/protocol.mb.go
+++ b/types/go/primitives/protocol.mb.go
@@ -1,4 +1,4 @@
-// AUTO GENERATED FILE (by membufc proto compiler v0.0.19)
+// AUTO GENERATED FILE (by membufc proto compiler v0.0.20)
 package primitives
 
 import (

--- a/types/go/protocol/blocks.mb.go
+++ b/types/go/protocol/blocks.mb.go
@@ -1,4 +1,4 @@
-// AUTO GENERATED FILE (by membufc proto compiler v0.0.19)
+// AUTO GENERATED FILE (by membufc proto compiler v0.0.20)
 package protocol
 
 import (

--- a/types/go/protocol/client/requests.mb.go
+++ b/types/go/protocol/client/requests.mb.go
@@ -1,4 +1,4 @@
-// AUTO GENERATED FILE (by membufc proto compiler v0.0.19)
+// AUTO GENERATED FILE (by membufc proto compiler v0.0.20)
 package client
 
 import (

--- a/types/go/protocol/consensus/all.mb.go
+++ b/types/go/protocol/consensus/all.mb.go
@@ -1,4 +1,4 @@
-// AUTO GENERATED FILE (by membufc proto compiler v0.0.19)
+// AUTO GENERATED FILE (by membufc proto compiler v0.0.20)
 package consensus
 
 import (

--- a/types/go/protocol/consensus/benchmark_consensus.mb.go
+++ b/types/go/protocol/consensus/benchmark_consensus.mb.go
@@ -1,4 +1,4 @@
-// AUTO GENERATED FILE (by membufc proto compiler v0.0.19)
+// AUTO GENERATED FILE (by membufc proto compiler v0.0.20)
 package consensus
 
 import (

--- a/types/go/protocol/consensus/lean_helix.mb.go
+++ b/types/go/protocol/consensus/lean_helix.mb.go
@@ -1,4 +1,4 @@
-// AUTO GENERATED FILE (by membufc proto compiler v0.0.19)
+// AUTO GENERATED FILE (by membufc proto compiler v0.0.20)
 package consensus
 
 import (

--- a/types/go/protocol/contracts.mb.go
+++ b/types/go/protocol/contracts.mb.go
@@ -1,4 +1,4 @@
-// AUTO GENERATED FILE (by membufc proto compiler v0.0.19)
+// AUTO GENERATED FILE (by membufc proto compiler v0.0.20)
 package protocol
 
 import (
@@ -756,6 +756,7 @@ type ProcessorType uint16
 const (
 	PROCESSOR_TYPE_RESERVED ProcessorType = 0
 	PROCESSOR_TYPE_NATIVE ProcessorType = 1
+	PROCESSOR_TYPE_JAVASCRIPT ProcessorType = 2
 )
 
 func (n ProcessorType) String() string {
@@ -764,6 +765,8 @@ func (n ProcessorType) String() string {
 		return "PROCESSOR_TYPE_RESERVED"
 	case PROCESSOR_TYPE_NATIVE:
 		return "PROCESSOR_TYPE_NATIVE"
+	case PROCESSOR_TYPE_JAVASCRIPT:
+		return "PROCESSOR_TYPE_JAVASCRIPT"
 	}
 	return "UNKNOWN"
 }

--- a/types/go/protocol/gossipmessages/all.mb.go
+++ b/types/go/protocol/gossipmessages/all.mb.go
@@ -1,4 +1,4 @@
-// AUTO GENERATED FILE (by membufc proto compiler v0.0.19)
+// AUTO GENERATED FILE (by membufc proto compiler v0.0.20)
 package gossipmessages
 
 import (

--- a/types/go/protocol/gossipmessages/benchmark_consensus.mb.go
+++ b/types/go/protocol/gossipmessages/benchmark_consensus.mb.go
@@ -1,4 +1,4 @@
-// AUTO GENERATED FILE (by membufc proto compiler v0.0.19)
+// AUTO GENERATED FILE (by membufc proto compiler v0.0.20)
 package gossipmessages
 
 import (

--- a/types/go/protocol/gossipmessages/block_sync.mb.go
+++ b/types/go/protocol/gossipmessages/block_sync.mb.go
@@ -1,4 +1,4 @@
-// AUTO GENERATED FILE (by membufc proto compiler v0.0.19)
+// AUTO GENERATED FILE (by membufc proto compiler v0.0.20)
 package gossipmessages
 
 import (

--- a/types/go/protocol/gossipmessages/lean_helix.mb.go
+++ b/types/go/protocol/gossipmessages/lean_helix.mb.go
@@ -1,4 +1,4 @@
-// AUTO GENERATED FILE (by membufc proto compiler v0.0.19)
+// AUTO GENERATED FILE (by membufc proto compiler v0.0.20)
 package gossipmessages
 
 import (

--- a/types/go/protocol/gossipmessages/transaction_relay.mb.go
+++ b/types/go/protocol/gossipmessages/transaction_relay.mb.go
@@ -1,4 +1,4 @@
-// AUTO GENERATED FILE (by membufc proto compiler v0.0.19)
+// AUTO GENERATED FILE (by membufc proto compiler v0.0.20)
 package gossipmessages
 
 import (

--- a/types/go/protocol/results.mb.go
+++ b/types/go/protocol/results.mb.go
@@ -1,4 +1,4 @@
-// AUTO GENERATED FILE (by membufc proto compiler v0.0.19)
+// AUTO GENERATED FILE (by membufc proto compiler v0.0.20)
 package protocol
 
 import (
@@ -35,6 +35,7 @@ const (
 	EXECUTION_RESULT_ERROR_SMART_CONTRACT ExecutionResult = 2
 	EXECUTION_RESULT_ERROR_INPUT ExecutionResult = 3
 	EXECUTION_RESULT_ERROR_UNEXPECTED ExecutionResult = 4
+	EXECUTION_RESULT_STATE_WRITE_IN_A_CALL ExecutionResult = 5
 )
 
 func (n ExecutionResult) String() string {
@@ -49,6 +50,8 @@ func (n ExecutionResult) String() string {
 		return "EXECUTION_RESULT_ERROR_INPUT"
 	case EXECUTION_RESULT_ERROR_UNEXPECTED:
 		return "EXECUTION_RESULT_ERROR_UNEXPECTED"
+	case EXECUTION_RESULT_STATE_WRITE_IN_A_CALL:
+		return "EXECUTION_RESULT_STATE_WRITE_IN_A_CALL"
 	}
 	return "UNKNOWN"
 }

--- a/types/go/protocol/signers.mb.go
+++ b/types/go/protocol/signers.mb.go
@@ -1,4 +1,4 @@
-// AUTO GENERATED FILE (by membufc proto compiler v0.0.19)
+// AUTO GENERATED FILE (by membufc proto compiler v0.0.20)
 package protocol
 
 import (

--- a/types/go/protocol/transactions.mb.go
+++ b/types/go/protocol/transactions.mb.go
@@ -1,4 +1,4 @@
-// AUTO GENERATED FILE (by membufc proto compiler v0.0.19)
+// AUTO GENERATED FILE (by membufc proto compiler v0.0.20)
 package protocol
 
 import (

--- a/types/go/services/block_storage.mb.go
+++ b/types/go/services/block_storage.mb.go
@@ -3,6 +3,7 @@ package services
 
 import (
 	"fmt"
+	"context"
 	"github.com/orbs-network/orbs-spec/types/go/primitives"
 	"github.com/orbs-network/orbs-spec/types/go/protocol"
 	"github.com/orbs-network/orbs-spec/types/go/services/gossiptopics"
@@ -14,12 +15,12 @@ import (
 
 type BlockStorage interface {
 	gossiptopics.BlockSyncHandler
-	CommitBlock(input *CommitBlockInput) (*CommitBlockOutput, error)
-	GetTransactionsBlockHeader(input *GetTransactionsBlockHeaderInput) (*GetTransactionsBlockHeaderOutput, error)
-	GetResultsBlockHeader(input *GetResultsBlockHeaderInput) (*GetResultsBlockHeaderOutput, error)
-	GetTransactionReceipt(input *GetTransactionReceiptInput) (*GetTransactionReceiptOutput, error)
-	GetLastCommittedBlockHeight(input *GetLastCommittedBlockHeightInput) (*GetLastCommittedBlockHeightOutput, error)
-	ValidateBlockForCommit(input *ValidateBlockForCommitInput) (*ValidateBlockForCommitOutput, error)
+	CommitBlock(ctx context.Context, input *CommitBlockInput) (*CommitBlockOutput, error)
+	GetTransactionsBlockHeader(ctx context.Context, input *GetTransactionsBlockHeaderInput) (*GetTransactionsBlockHeaderOutput, error)
+	GetResultsBlockHeader(ctx context.Context, input *GetResultsBlockHeaderInput) (*GetResultsBlockHeaderOutput, error)
+	GetTransactionReceipt(ctx context.Context, input *GetTransactionReceiptInput) (*GetTransactionReceiptOutput, error)
+	GetLastCommittedBlockHeight(ctx context.Context, input *GetLastCommittedBlockHeightInput) (*GetLastCommittedBlockHeightOutput, error)
+	ValidateBlockForCommit(ctx context.Context, input *ValidateBlockForCommitInput) (*ValidateBlockForCommitOutput, error)
 	RegisterConsensusBlocksHandler(handler handlers.ConsensusBlocksHandler)
 }
 

--- a/types/go/services/block_storage.mb.go
+++ b/types/go/services/block_storage.mb.go
@@ -1,4 +1,4 @@
-// AUTO GENERATED FILE (by membufc proto compiler v0.0.19)
+// AUTO GENERATED FILE (by membufc proto compiler v0.0.20)
 package services
 
 import (

--- a/types/go/services/block_storage_mock.mb.go
+++ b/types/go/services/block_storage_mock.mb.go
@@ -1,4 +1,4 @@
-// AUTO GENERATED FILE (by membufc proto compiler v0.0.19)
+// AUTO GENERATED FILE (by membufc proto compiler v0.0.20)
 package services
 
 import (

--- a/types/go/services/block_storage_mock.mb.go
+++ b/types/go/services/block_storage_mock.mb.go
@@ -3,6 +3,7 @@ package services
 
 import (
 	"github.com/orbs-network/go-mock"
+	"context"
 	"github.com/orbs-network/orbs-spec/types/go/services/gossiptopics"
 	"github.com/orbs-network/orbs-spec/types/go/services/handlers"
 )
@@ -15,8 +16,8 @@ type MockBlockStorage struct {
 	gossiptopics.MockBlockSyncHandler
 }
 
-func (s *MockBlockStorage) CommitBlock(input *CommitBlockInput) (*CommitBlockOutput, error) {
-	ret := s.Called(input)
+func (s *MockBlockStorage) CommitBlock(ctx context.Context, input *CommitBlockInput) (*CommitBlockOutput, error) {
+	ret := s.Called(ctx, input)
 	if out := ret.Get(0); out != nil {
 		return out.(*CommitBlockOutput), ret.Error(1)
 	} else {
@@ -24,8 +25,8 @@ func (s *MockBlockStorage) CommitBlock(input *CommitBlockInput) (*CommitBlockOut
 	}
 }
 
-func (s *MockBlockStorage) GetTransactionsBlockHeader(input *GetTransactionsBlockHeaderInput) (*GetTransactionsBlockHeaderOutput, error) {
-	ret := s.Called(input)
+func (s *MockBlockStorage) GetTransactionsBlockHeader(ctx context.Context, input *GetTransactionsBlockHeaderInput) (*GetTransactionsBlockHeaderOutput, error) {
+	ret := s.Called(ctx, input)
 	if out := ret.Get(0); out != nil {
 		return out.(*GetTransactionsBlockHeaderOutput), ret.Error(1)
 	} else {
@@ -33,8 +34,8 @@ func (s *MockBlockStorage) GetTransactionsBlockHeader(input *GetTransactionsBloc
 	}
 }
 
-func (s *MockBlockStorage) GetResultsBlockHeader(input *GetResultsBlockHeaderInput) (*GetResultsBlockHeaderOutput, error) {
-	ret := s.Called(input)
+func (s *MockBlockStorage) GetResultsBlockHeader(ctx context.Context, input *GetResultsBlockHeaderInput) (*GetResultsBlockHeaderOutput, error) {
+	ret := s.Called(ctx, input)
 	if out := ret.Get(0); out != nil {
 		return out.(*GetResultsBlockHeaderOutput), ret.Error(1)
 	} else {
@@ -42,8 +43,8 @@ func (s *MockBlockStorage) GetResultsBlockHeader(input *GetResultsBlockHeaderInp
 	}
 }
 
-func (s *MockBlockStorage) GetTransactionReceipt(input *GetTransactionReceiptInput) (*GetTransactionReceiptOutput, error) {
-	ret := s.Called(input)
+func (s *MockBlockStorage) GetTransactionReceipt(ctx context.Context, input *GetTransactionReceiptInput) (*GetTransactionReceiptOutput, error) {
+	ret := s.Called(ctx, input)
 	if out := ret.Get(0); out != nil {
 		return out.(*GetTransactionReceiptOutput), ret.Error(1)
 	} else {
@@ -51,8 +52,8 @@ func (s *MockBlockStorage) GetTransactionReceipt(input *GetTransactionReceiptInp
 	}
 }
 
-func (s *MockBlockStorage) GetLastCommittedBlockHeight(input *GetLastCommittedBlockHeightInput) (*GetLastCommittedBlockHeightOutput, error) {
-	ret := s.Called(input)
+func (s *MockBlockStorage) GetLastCommittedBlockHeight(ctx context.Context, input *GetLastCommittedBlockHeightInput) (*GetLastCommittedBlockHeightOutput, error) {
+	ret := s.Called(ctx, input)
 	if out := ret.Get(0); out != nil {
 		return out.(*GetLastCommittedBlockHeightOutput), ret.Error(1)
 	} else {
@@ -60,8 +61,8 @@ func (s *MockBlockStorage) GetLastCommittedBlockHeight(input *GetLastCommittedBl
 	}
 }
 
-func (s *MockBlockStorage) ValidateBlockForCommit(input *ValidateBlockForCommitInput) (*ValidateBlockForCommitOutput, error) {
-	ret := s.Called(input)
+func (s *MockBlockStorage) ValidateBlockForCommit(ctx context.Context, input *ValidateBlockForCommitInput) (*ValidateBlockForCommitOutput, error) {
+	ret := s.Called(ctx, input)
 	if out := ret.Get(0); out != nil {
 		return out.(*ValidateBlockForCommitOutput), ret.Error(1)
 	} else {

--- a/types/go/services/consensus_algo.mb.go
+++ b/types/go/services/consensus_algo.mb.go
@@ -1,4 +1,4 @@
-// AUTO GENERATED FILE (by membufc proto compiler v0.0.19)
+// AUTO GENERATED FILE (by membufc proto compiler v0.0.20)
 package services
 
 import (

--- a/types/go/services/consensus_algo_mock.mb.go
+++ b/types/go/services/consensus_algo_mock.mb.go
@@ -1,4 +1,4 @@
-// AUTO GENERATED FILE (by membufc proto compiler v0.0.19)
+// AUTO GENERATED FILE (by membufc proto compiler v0.0.20)
 package services
 
 import (

--- a/types/go/services/consensus_context.mb.go
+++ b/types/go/services/consensus_context.mb.go
@@ -1,4 +1,4 @@
-// AUTO GENERATED FILE (by membufc proto compiler v0.0.19)
+// AUTO GENERATED FILE (by membufc proto compiler v0.0.20)
 package services
 
 import (

--- a/types/go/services/consensus_context.mb.go
+++ b/types/go/services/consensus_context.mb.go
@@ -3,6 +3,7 @@ package services
 
 import (
 	"fmt"
+	"context"
 	"github.com/orbs-network/orbs-spec/types/go/primitives"
 	"github.com/orbs-network/orbs-spec/types/go/protocol"
 )
@@ -11,12 +12,12 @@ import (
 // service ConsensusContext
 
 type ConsensusContext interface {
-	RequestNewTransactionsBlock(input *RequestNewTransactionsBlockInput) (*RequestNewTransactionsBlockOutput, error)
-	RequestNewResultsBlock(input *RequestNewResultsBlockInput) (*RequestNewResultsBlockOutput, error)
-	ValidateTransactionsBlock(input *ValidateTransactionsBlockInput) (*ValidateTransactionsBlockOutput, error)
-	ValidateResultsBlock(input *ValidateResultsBlockInput) (*ValidateResultsBlockOutput, error)
-	RequestOrderingCommittee(input *RequestCommitteeInput) (*RequestCommitteeOutput, error)
-	RequestValidationCommittee(input *RequestCommitteeInput) (*RequestCommitteeOutput, error)
+	RequestNewTransactionsBlock(ctx context.Context, input *RequestNewTransactionsBlockInput) (*RequestNewTransactionsBlockOutput, error)
+	RequestNewResultsBlock(ctx context.Context, input *RequestNewResultsBlockInput) (*RequestNewResultsBlockOutput, error)
+	ValidateTransactionsBlock(ctx context.Context, input *ValidateTransactionsBlockInput) (*ValidateTransactionsBlockOutput, error)
+	ValidateResultsBlock(ctx context.Context, input *ValidateResultsBlockInput) (*ValidateResultsBlockOutput, error)
+	RequestOrderingCommittee(ctx context.Context, input *RequestCommitteeInput) (*RequestCommitteeOutput, error)
+	RequestValidationCommittee(ctx context.Context, input *RequestCommitteeInput) (*RequestCommitteeOutput, error)
 }
 
 /////////////////////////////////////////////////////////////////////////////

--- a/types/go/services/consensus_context_mock.mb.go
+++ b/types/go/services/consensus_context_mock.mb.go
@@ -1,4 +1,4 @@
-// AUTO GENERATED FILE (by membufc proto compiler v0.0.19)
+// AUTO GENERATED FILE (by membufc proto compiler v0.0.20)
 package services
 
 import (

--- a/types/go/services/consensus_context_mock.mb.go
+++ b/types/go/services/consensus_context_mock.mb.go
@@ -3,6 +3,7 @@ package services
 
 import (
 	"github.com/orbs-network/go-mock"
+	"context"
 )
 
 /////////////////////////////////////////////////////////////////////////////
@@ -12,8 +13,8 @@ type MockConsensusContext struct {
 	mock.Mock
 }
 
-func (s *MockConsensusContext) RequestNewTransactionsBlock(input *RequestNewTransactionsBlockInput) (*RequestNewTransactionsBlockOutput, error) {
-	ret := s.Called(input)
+func (s *MockConsensusContext) RequestNewTransactionsBlock(ctx context.Context, input *RequestNewTransactionsBlockInput) (*RequestNewTransactionsBlockOutput, error) {
+	ret := s.Called(ctx, input)
 	if out := ret.Get(0); out != nil {
 		return out.(*RequestNewTransactionsBlockOutput), ret.Error(1)
 	} else {
@@ -21,8 +22,8 @@ func (s *MockConsensusContext) RequestNewTransactionsBlock(input *RequestNewTran
 	}
 }
 
-func (s *MockConsensusContext) RequestNewResultsBlock(input *RequestNewResultsBlockInput) (*RequestNewResultsBlockOutput, error) {
-	ret := s.Called(input)
+func (s *MockConsensusContext) RequestNewResultsBlock(ctx context.Context, input *RequestNewResultsBlockInput) (*RequestNewResultsBlockOutput, error) {
+	ret := s.Called(ctx, input)
 	if out := ret.Get(0); out != nil {
 		return out.(*RequestNewResultsBlockOutput), ret.Error(1)
 	} else {
@@ -30,8 +31,8 @@ func (s *MockConsensusContext) RequestNewResultsBlock(input *RequestNewResultsBl
 	}
 }
 
-func (s *MockConsensusContext) ValidateTransactionsBlock(input *ValidateTransactionsBlockInput) (*ValidateTransactionsBlockOutput, error) {
-	ret := s.Called(input)
+func (s *MockConsensusContext) ValidateTransactionsBlock(ctx context.Context, input *ValidateTransactionsBlockInput) (*ValidateTransactionsBlockOutput, error) {
+	ret := s.Called(ctx, input)
 	if out := ret.Get(0); out != nil {
 		return out.(*ValidateTransactionsBlockOutput), ret.Error(1)
 	} else {
@@ -39,8 +40,8 @@ func (s *MockConsensusContext) ValidateTransactionsBlock(input *ValidateTransact
 	}
 }
 
-func (s *MockConsensusContext) ValidateResultsBlock(input *ValidateResultsBlockInput) (*ValidateResultsBlockOutput, error) {
-	ret := s.Called(input)
+func (s *MockConsensusContext) ValidateResultsBlock(ctx context.Context, input *ValidateResultsBlockInput) (*ValidateResultsBlockOutput, error) {
+	ret := s.Called(ctx, input)
 	if out := ret.Get(0); out != nil {
 		return out.(*ValidateResultsBlockOutput), ret.Error(1)
 	} else {
@@ -48,8 +49,8 @@ func (s *MockConsensusContext) ValidateResultsBlock(input *ValidateResultsBlockI
 	}
 }
 
-func (s *MockConsensusContext) RequestOrderingCommittee(input *RequestCommitteeInput) (*RequestCommitteeOutput, error) {
-	ret := s.Called(input)
+func (s *MockConsensusContext) RequestOrderingCommittee(ctx context.Context, input *RequestCommitteeInput) (*RequestCommitteeOutput, error) {
+	ret := s.Called(ctx, input)
 	if out := ret.Get(0); out != nil {
 		return out.(*RequestCommitteeOutput), ret.Error(1)
 	} else {
@@ -57,8 +58,8 @@ func (s *MockConsensusContext) RequestOrderingCommittee(input *RequestCommitteeI
 	}
 }
 
-func (s *MockConsensusContext) RequestValidationCommittee(input *RequestCommitteeInput) (*RequestCommitteeOutput, error) {
-	ret := s.Called(input)
+func (s *MockConsensusContext) RequestValidationCommittee(ctx context.Context, input *RequestCommitteeInput) (*RequestCommitteeOutput, error) {
+	ret := s.Called(ctx, input)
 	if out := ret.Get(0); out != nil {
 		return out.(*RequestCommitteeOutput), ret.Error(1)
 	} else {

--- a/types/go/services/crosschain_connector.mb.go
+++ b/types/go/services/crosschain_connector.mb.go
@@ -3,6 +3,7 @@ package services
 
 import (
 	"fmt"
+	"context"
 	"github.com/orbs-network/orbs-spec/types/go/primitives"
 	"github.com/orbs-network/orbs-spec/types/go/protocol"
 )
@@ -11,7 +12,7 @@ import (
 // service CrosschainConnector
 
 type CrosschainConnector interface {
-	EthereumCallContract(input *EthereumCallContractInput) (*EthereumCallContractOutput, error)
+	EthereumCallContract(ctx context.Context, input *EthereumCallContractInput) (*EthereumCallContractOutput, error)
 }
 
 /////////////////////////////////////////////////////////////////////////////

--- a/types/go/services/crosschain_connector.mb.go
+++ b/types/go/services/crosschain_connector.mb.go
@@ -1,4 +1,4 @@
-// AUTO GENERATED FILE (by membufc proto compiler v0.0.19)
+// AUTO GENERATED FILE (by membufc proto compiler v0.0.20)
 package services
 
 import (
@@ -20,16 +20,16 @@ type CrosschainConnector interface {
 type EthereumCallContractInput struct {
 	BlockHeight primitives.BlockHeight
 	EthereumContractAddress string
-	EthereumFunctionCanonicalForm string
+	EthereumFunctionName string
+	EthereumAbi string
 	InputArguments []*protocol.MethodArgument
-	EthereumBlockHeight uint64
 }
 
 func (x *EthereumCallContractInput) String() string {
 	if x == nil {
 		return "<nil>"
 	}
-	return fmt.Sprintf("{BlockHeight:%s,EthereumContractAddress:%s,EthereumFunctionCanonicalForm:%s,InputArguments:%s,EthereumBlockHeight:%s,}", x.StringBlockHeight(), x.StringEthereumContractAddress(), x.StringEthereumFunctionCanonicalForm(), x.StringInputArguments(), x.StringEthereumBlockHeight())
+	return fmt.Sprintf("{BlockHeight:%s,EthereumContractAddress:%s,EthereumFunctionName:%s,EthereumAbi:%s,InputArguments:%s,}", x.StringBlockHeight(), x.StringEthereumContractAddress(), x.StringEthereumFunctionName(), x.StringEthereumAbi(), x.StringInputArguments())
 }
 
 func (x *EthereumCallContractInput) StringBlockHeight() (res string) {
@@ -42,8 +42,13 @@ func (x *EthereumCallContractInput) StringEthereumContractAddress() (res string)
 	return
 }
 
-func (x *EthereumCallContractInput) StringEthereumFunctionCanonicalForm() (res string) {
-	res = fmt.Sprintf(x.EthereumFunctionCanonicalForm)
+func (x *EthereumCallContractInput) StringEthereumFunctionName() (res string) {
+	res = fmt.Sprintf(x.EthereumFunctionName)
+	return
+}
+
+func (x *EthereumCallContractInput) StringEthereumAbi() (res string) {
+	res = fmt.Sprintf(x.EthereumAbi)
 	return
 }
 
@@ -53,11 +58,6 @@ func (x *EthereumCallContractInput) StringInputArguments() (res string) {
 		res += v.String() + ","
   }
 	res += "]"
-	return
-}
-
-func (x *EthereumCallContractInput) StringEthereumBlockHeight() (res string) {
-	res = fmt.Sprintf("%x", x.EthereumBlockHeight)
 	return
 }
 

--- a/types/go/services/crosschain_connector_mock.mb.go
+++ b/types/go/services/crosschain_connector_mock.mb.go
@@ -3,6 +3,7 @@ package services
 
 import (
 	"github.com/orbs-network/go-mock"
+	"context"
 )
 
 /////////////////////////////////////////////////////////////////////////////
@@ -12,8 +13,8 @@ type MockCrosschainConnector struct {
 	mock.Mock
 }
 
-func (s *MockCrosschainConnector) EthereumCallContract(input *EthereumCallContractInput) (*EthereumCallContractOutput, error) {
-	ret := s.Called(input)
+func (s *MockCrosschainConnector) EthereumCallContract(ctx context.Context, input *EthereumCallContractInput) (*EthereumCallContractOutput, error) {
+	ret := s.Called(ctx, input)
 	if out := ret.Get(0); out != nil {
 		return out.(*EthereumCallContractOutput), ret.Error(1)
 	} else {

--- a/types/go/services/crosschain_connector_mock.mb.go
+++ b/types/go/services/crosschain_connector_mock.mb.go
@@ -1,4 +1,4 @@
-// AUTO GENERATED FILE (by membufc proto compiler v0.0.19)
+// AUTO GENERATED FILE (by membufc proto compiler v0.0.20)
 package services
 
 import (

--- a/types/go/services/gossip.mb.go
+++ b/types/go/services/gossip.mb.go
@@ -1,4 +1,4 @@
-// AUTO GENERATED FILE (by membufc proto compiler v0.0.19)
+// AUTO GENERATED FILE (by membufc proto compiler v0.0.20)
 package services
 
 import (

--- a/types/go/services/gossip_mock.mb.go
+++ b/types/go/services/gossip_mock.mb.go
@@ -1,4 +1,4 @@
-// AUTO GENERATED FILE (by membufc proto compiler v0.0.19)
+// AUTO GENERATED FILE (by membufc proto compiler v0.0.20)
 package services
 
 import (

--- a/types/go/services/gossiptopics/all.mb.go
+++ b/types/go/services/gossiptopics/all.mb.go
@@ -1,4 +1,4 @@
-// AUTO GENERATED FILE (by membufc proto compiler v0.0.19)
+// AUTO GENERATED FILE (by membufc proto compiler v0.0.20)
 package gossiptopics
 
 import (

--- a/types/go/services/gossiptopics/benchmark_consensus.mb.go
+++ b/types/go/services/gossiptopics/benchmark_consensus.mb.go
@@ -1,4 +1,4 @@
-// AUTO GENERATED FILE (by membufc proto compiler v0.0.19)
+// AUTO GENERATED FILE (by membufc proto compiler v0.0.20)
 package gossiptopics
 
 import (

--- a/types/go/services/gossiptopics/benchmark_consensus.mb.go
+++ b/types/go/services/gossiptopics/benchmark_consensus.mb.go
@@ -3,6 +3,7 @@ package gossiptopics
 
 import (
 	"fmt"
+	"context"
 	"github.com/orbs-network/orbs-spec/types/go/primitives"
 	"github.com/orbs-network/orbs-spec/types/go/protocol/gossipmessages"
 )
@@ -11,8 +12,8 @@ import (
 // service BenchmarkConsensus
 
 type BenchmarkConsensus interface {
-	BroadcastBenchmarkConsensusCommit(input *BenchmarkConsensusCommitInput) (*EmptyOutput, error)
-	SendBenchmarkConsensusCommitted(input *BenchmarkConsensusCommittedInput) (*EmptyOutput, error)
+	BroadcastBenchmarkConsensusCommit(ctx context.Context, input *BenchmarkConsensusCommitInput) (*EmptyOutput, error)
+	SendBenchmarkConsensusCommitted(ctx context.Context, input *BenchmarkConsensusCommittedInput) (*EmptyOutput, error)
 	RegisterBenchmarkConsensusHandler(handler BenchmarkConsensusHandler)
 }
 
@@ -20,8 +21,8 @@ type BenchmarkConsensus interface {
 // service BenchmarkConsensusHandler
 
 type BenchmarkConsensusHandler interface {
-	HandleBenchmarkConsensusCommit(input *BenchmarkConsensusCommitInput) (*EmptyOutput, error)
-	HandleBenchmarkConsensusCommitted(input *BenchmarkConsensusCommittedInput) (*EmptyOutput, error)
+	HandleBenchmarkConsensusCommit(ctx context.Context, input *BenchmarkConsensusCommitInput) (*EmptyOutput, error)
+	HandleBenchmarkConsensusCommitted(ctx context.Context, input *BenchmarkConsensusCommittedInput) (*EmptyOutput, error)
 }
 
 /////////////////////////////////////////////////////////////////////////////

--- a/types/go/services/gossiptopics/benchmark_consensus_mock.mb.go
+++ b/types/go/services/gossiptopics/benchmark_consensus_mock.mb.go
@@ -3,6 +3,7 @@ package gossiptopics
 
 import (
 	"github.com/orbs-network/go-mock"
+	"context"
 )
 
 /////////////////////////////////////////////////////////////////////////////
@@ -12,8 +13,8 @@ type MockBenchmarkConsensus struct {
 	mock.Mock
 }
 
-func (s *MockBenchmarkConsensus) BroadcastBenchmarkConsensusCommit(input *BenchmarkConsensusCommitInput) (*EmptyOutput, error) {
-	ret := s.Called(input)
+func (s *MockBenchmarkConsensus) BroadcastBenchmarkConsensusCommit(ctx context.Context, input *BenchmarkConsensusCommitInput) (*EmptyOutput, error) {
+	ret := s.Called(ctx, input)
 	if out := ret.Get(0); out != nil {
 		return out.(*EmptyOutput), ret.Error(1)
 	} else {
@@ -21,8 +22,8 @@ func (s *MockBenchmarkConsensus) BroadcastBenchmarkConsensusCommit(input *Benchm
 	}
 }
 
-func (s *MockBenchmarkConsensus) SendBenchmarkConsensusCommitted(input *BenchmarkConsensusCommittedInput) (*EmptyOutput, error) {
-	ret := s.Called(input)
+func (s *MockBenchmarkConsensus) SendBenchmarkConsensusCommitted(ctx context.Context, input *BenchmarkConsensusCommittedInput) (*EmptyOutput, error) {
+	ret := s.Called(ctx, input)
 	if out := ret.Get(0); out != nil {
 		return out.(*EmptyOutput), ret.Error(1)
 	} else {
@@ -41,8 +42,8 @@ type MockBenchmarkConsensusHandler struct {
 	mock.Mock
 }
 
-func (s *MockBenchmarkConsensusHandler) HandleBenchmarkConsensusCommit(input *BenchmarkConsensusCommitInput) (*EmptyOutput, error) {
-	ret := s.Called(input)
+func (s *MockBenchmarkConsensusHandler) HandleBenchmarkConsensusCommit(ctx context.Context, input *BenchmarkConsensusCommitInput) (*EmptyOutput, error) {
+	ret := s.Called(ctx, input)
 	if out := ret.Get(0); out != nil {
 		return out.(*EmptyOutput), ret.Error(1)
 	} else {
@@ -50,8 +51,8 @@ func (s *MockBenchmarkConsensusHandler) HandleBenchmarkConsensusCommit(input *Be
 	}
 }
 
-func (s *MockBenchmarkConsensusHandler) HandleBenchmarkConsensusCommitted(input *BenchmarkConsensusCommittedInput) (*EmptyOutput, error) {
-	ret := s.Called(input)
+func (s *MockBenchmarkConsensusHandler) HandleBenchmarkConsensusCommitted(ctx context.Context, input *BenchmarkConsensusCommittedInput) (*EmptyOutput, error) {
+	ret := s.Called(ctx, input)
 	if out := ret.Get(0); out != nil {
 		return out.(*EmptyOutput), ret.Error(1)
 	} else {

--- a/types/go/services/gossiptopics/benchmark_consensus_mock.mb.go
+++ b/types/go/services/gossiptopics/benchmark_consensus_mock.mb.go
@@ -1,4 +1,4 @@
-// AUTO GENERATED FILE (by membufc proto compiler v0.0.19)
+// AUTO GENERATED FILE (by membufc proto compiler v0.0.20)
 package gossiptopics
 
 import (

--- a/types/go/services/gossiptopics/block_sync.mb.go
+++ b/types/go/services/gossiptopics/block_sync.mb.go
@@ -1,4 +1,4 @@
-// AUTO GENERATED FILE (by membufc proto compiler v0.0.19)
+// AUTO GENERATED FILE (by membufc proto compiler v0.0.20)
 package gossiptopics
 
 import (

--- a/types/go/services/gossiptopics/block_sync.mb.go
+++ b/types/go/services/gossiptopics/block_sync.mb.go
@@ -3,6 +3,7 @@ package gossiptopics
 
 import (
 	"fmt"
+	"context"
 	"github.com/orbs-network/orbs-spec/types/go/primitives"
 	"github.com/orbs-network/orbs-spec/types/go/protocol/gossipmessages"
 )
@@ -11,10 +12,10 @@ import (
 // service BlockSync
 
 type BlockSync interface {
-	BroadcastBlockAvailabilityRequest(input *BlockAvailabilityRequestInput) (*EmptyOutput, error)
-	SendBlockAvailabilityResponse(input *BlockAvailabilityResponseInput) (*EmptyOutput, error)
-	SendBlockSyncRequest(input *BlockSyncRequestInput) (*EmptyOutput, error)
-	SendBlockSyncResponse(input *BlockSyncResponseInput) (*EmptyOutput, error)
+	BroadcastBlockAvailabilityRequest(ctx context.Context, input *BlockAvailabilityRequestInput) (*EmptyOutput, error)
+	SendBlockAvailabilityResponse(ctx context.Context, input *BlockAvailabilityResponseInput) (*EmptyOutput, error)
+	SendBlockSyncRequest(ctx context.Context, input *BlockSyncRequestInput) (*EmptyOutput, error)
+	SendBlockSyncResponse(ctx context.Context, input *BlockSyncResponseInput) (*EmptyOutput, error)
 	RegisterBlockSyncHandler(handler BlockSyncHandler)
 }
 
@@ -22,10 +23,10 @@ type BlockSync interface {
 // service BlockSyncHandler
 
 type BlockSyncHandler interface {
-	HandleBlockAvailabilityRequest(input *BlockAvailabilityRequestInput) (*EmptyOutput, error)
-	HandleBlockAvailabilityResponse(input *BlockAvailabilityResponseInput) (*EmptyOutput, error)
-	HandleBlockSyncRequest(input *BlockSyncRequestInput) (*EmptyOutput, error)
-	HandleBlockSyncResponse(input *BlockSyncResponseInput) (*EmptyOutput, error)
+	HandleBlockAvailabilityRequest(ctx context.Context, input *BlockAvailabilityRequestInput) (*EmptyOutput, error)
+	HandleBlockAvailabilityResponse(ctx context.Context, input *BlockAvailabilityResponseInput) (*EmptyOutput, error)
+	HandleBlockSyncRequest(ctx context.Context, input *BlockSyncRequestInput) (*EmptyOutput, error)
+	HandleBlockSyncResponse(ctx context.Context, input *BlockSyncResponseInput) (*EmptyOutput, error)
 }
 
 /////////////////////////////////////////////////////////////////////////////

--- a/types/go/services/gossiptopics/block_sync_mock.mb.go
+++ b/types/go/services/gossiptopics/block_sync_mock.mb.go
@@ -3,6 +3,7 @@ package gossiptopics
 
 import (
 	"github.com/orbs-network/go-mock"
+	"context"
 )
 
 /////////////////////////////////////////////////////////////////////////////
@@ -12,8 +13,8 @@ type MockBlockSync struct {
 	mock.Mock
 }
 
-func (s *MockBlockSync) BroadcastBlockAvailabilityRequest(input *BlockAvailabilityRequestInput) (*EmptyOutput, error) {
-	ret := s.Called(input)
+func (s *MockBlockSync) BroadcastBlockAvailabilityRequest(ctx context.Context, input *BlockAvailabilityRequestInput) (*EmptyOutput, error) {
+	ret := s.Called(ctx, input)
 	if out := ret.Get(0); out != nil {
 		return out.(*EmptyOutput), ret.Error(1)
 	} else {
@@ -21,8 +22,8 @@ func (s *MockBlockSync) BroadcastBlockAvailabilityRequest(input *BlockAvailabili
 	}
 }
 
-func (s *MockBlockSync) SendBlockAvailabilityResponse(input *BlockAvailabilityResponseInput) (*EmptyOutput, error) {
-	ret := s.Called(input)
+func (s *MockBlockSync) SendBlockAvailabilityResponse(ctx context.Context, input *BlockAvailabilityResponseInput) (*EmptyOutput, error) {
+	ret := s.Called(ctx, input)
 	if out := ret.Get(0); out != nil {
 		return out.(*EmptyOutput), ret.Error(1)
 	} else {
@@ -30,8 +31,8 @@ func (s *MockBlockSync) SendBlockAvailabilityResponse(input *BlockAvailabilityRe
 	}
 }
 
-func (s *MockBlockSync) SendBlockSyncRequest(input *BlockSyncRequestInput) (*EmptyOutput, error) {
-	ret := s.Called(input)
+func (s *MockBlockSync) SendBlockSyncRequest(ctx context.Context, input *BlockSyncRequestInput) (*EmptyOutput, error) {
+	ret := s.Called(ctx, input)
 	if out := ret.Get(0); out != nil {
 		return out.(*EmptyOutput), ret.Error(1)
 	} else {
@@ -39,8 +40,8 @@ func (s *MockBlockSync) SendBlockSyncRequest(input *BlockSyncRequestInput) (*Emp
 	}
 }
 
-func (s *MockBlockSync) SendBlockSyncResponse(input *BlockSyncResponseInput) (*EmptyOutput, error) {
-	ret := s.Called(input)
+func (s *MockBlockSync) SendBlockSyncResponse(ctx context.Context, input *BlockSyncResponseInput) (*EmptyOutput, error) {
+	ret := s.Called(ctx, input)
 	if out := ret.Get(0); out != nil {
 		return out.(*EmptyOutput), ret.Error(1)
 	} else {
@@ -59,8 +60,8 @@ type MockBlockSyncHandler struct {
 	mock.Mock
 }
 
-func (s *MockBlockSyncHandler) HandleBlockAvailabilityRequest(input *BlockAvailabilityRequestInput) (*EmptyOutput, error) {
-	ret := s.Called(input)
+func (s *MockBlockSyncHandler) HandleBlockAvailabilityRequest(ctx context.Context, input *BlockAvailabilityRequestInput) (*EmptyOutput, error) {
+	ret := s.Called(ctx, input)
 	if out := ret.Get(0); out != nil {
 		return out.(*EmptyOutput), ret.Error(1)
 	} else {
@@ -68,8 +69,8 @@ func (s *MockBlockSyncHandler) HandleBlockAvailabilityRequest(input *BlockAvaila
 	}
 }
 
-func (s *MockBlockSyncHandler) HandleBlockAvailabilityResponse(input *BlockAvailabilityResponseInput) (*EmptyOutput, error) {
-	ret := s.Called(input)
+func (s *MockBlockSyncHandler) HandleBlockAvailabilityResponse(ctx context.Context, input *BlockAvailabilityResponseInput) (*EmptyOutput, error) {
+	ret := s.Called(ctx, input)
 	if out := ret.Get(0); out != nil {
 		return out.(*EmptyOutput), ret.Error(1)
 	} else {
@@ -77,8 +78,8 @@ func (s *MockBlockSyncHandler) HandleBlockAvailabilityResponse(input *BlockAvail
 	}
 }
 
-func (s *MockBlockSyncHandler) HandleBlockSyncRequest(input *BlockSyncRequestInput) (*EmptyOutput, error) {
-	ret := s.Called(input)
+func (s *MockBlockSyncHandler) HandleBlockSyncRequest(ctx context.Context, input *BlockSyncRequestInput) (*EmptyOutput, error) {
+	ret := s.Called(ctx, input)
 	if out := ret.Get(0); out != nil {
 		return out.(*EmptyOutput), ret.Error(1)
 	} else {
@@ -86,8 +87,8 @@ func (s *MockBlockSyncHandler) HandleBlockSyncRequest(input *BlockSyncRequestInp
 	}
 }
 
-func (s *MockBlockSyncHandler) HandleBlockSyncResponse(input *BlockSyncResponseInput) (*EmptyOutput, error) {
-	ret := s.Called(input)
+func (s *MockBlockSyncHandler) HandleBlockSyncResponse(ctx context.Context, input *BlockSyncResponseInput) (*EmptyOutput, error) {
+	ret := s.Called(ctx, input)
 	if out := ret.Get(0); out != nil {
 		return out.(*EmptyOutput), ret.Error(1)
 	} else {

--- a/types/go/services/gossiptopics/block_sync_mock.mb.go
+++ b/types/go/services/gossiptopics/block_sync_mock.mb.go
@@ -1,4 +1,4 @@
-// AUTO GENERATED FILE (by membufc proto compiler v0.0.19)
+// AUTO GENERATED FILE (by membufc proto compiler v0.0.20)
 package gossiptopics
 
 import (

--- a/types/go/services/gossiptopics/lean_helix.mb.go
+++ b/types/go/services/gossiptopics/lean_helix.mb.go
@@ -3,6 +3,7 @@ package gossiptopics
 
 import (
 	"fmt"
+	"context"
 	"github.com/orbs-network/orbs-spec/types/go/protocol/gossipmessages"
 )
 
@@ -10,11 +11,11 @@ import (
 // service LeanHelix
 
 type LeanHelix interface {
-	SendLeanHelixPrePrepare(input *LeanHelixPrePrepareInput) (*EmptyOutput, error)
-	SendLeanHelixPrepare(input *LeanHelixPrepareInput) (*EmptyOutput, error)
-	SendLeanHelixCommit(input *LeanHelixCommitInput) (*EmptyOutput, error)
-	SendLeanHelixViewChange(input *LeanHelixViewChangeInput) (*EmptyOutput, error)
-	SendLeanHelixNewView(input *LeanHelixNewViewInput) (*EmptyOutput, error)
+	SendLeanHelixPrePrepare(ctx context.Context, input *LeanHelixPrePrepareInput) (*EmptyOutput, error)
+	SendLeanHelixPrepare(ctx context.Context, input *LeanHelixPrepareInput) (*EmptyOutput, error)
+	SendLeanHelixCommit(ctx context.Context, input *LeanHelixCommitInput) (*EmptyOutput, error)
+	SendLeanHelixViewChange(ctx context.Context, input *LeanHelixViewChangeInput) (*EmptyOutput, error)
+	SendLeanHelixNewView(ctx context.Context, input *LeanHelixNewViewInput) (*EmptyOutput, error)
 	RegisterLeanHelixHandler(handler LeanHelixHandler)
 }
 
@@ -22,11 +23,11 @@ type LeanHelix interface {
 // service LeanHelixHandler
 
 type LeanHelixHandler interface {
-	HandleLeanHelixPrePrepare(input *LeanHelixPrePrepareInput) (*EmptyOutput, error)
-	HandleLeanHelixPrepare(input *LeanHelixPrepareInput) (*EmptyOutput, error)
-	HandleLeanHelixCommit(input *LeanHelixCommitInput) (*EmptyOutput, error)
-	HandleLeanHelixViewChange(input *LeanHelixViewChangeInput) (*EmptyOutput, error)
-	HandleLeanHelixNewView(input *LeanHelixNewViewInput) (*EmptyOutput, error)
+	HandleLeanHelixPrePrepare(ctx context.Context, input *LeanHelixPrePrepareInput) (*EmptyOutput, error)
+	HandleLeanHelixPrepare(ctx context.Context, input *LeanHelixPrepareInput) (*EmptyOutput, error)
+	HandleLeanHelixCommit(ctx context.Context, input *LeanHelixCommitInput) (*EmptyOutput, error)
+	HandleLeanHelixViewChange(ctx context.Context, input *LeanHelixViewChangeInput) (*EmptyOutput, error)
+	HandleLeanHelixNewView(ctx context.Context, input *LeanHelixNewViewInput) (*EmptyOutput, error)
 }
 
 /////////////////////////////////////////////////////////////////////////////

--- a/types/go/services/gossiptopics/lean_helix.mb.go
+++ b/types/go/services/gossiptopics/lean_helix.mb.go
@@ -1,4 +1,4 @@
-// AUTO GENERATED FILE (by membufc proto compiler v0.0.19)
+// AUTO GENERATED FILE (by membufc proto compiler v0.0.20)
 package gossiptopics
 
 import (

--- a/types/go/services/gossiptopics/lean_helix_mock.mb.go
+++ b/types/go/services/gossiptopics/lean_helix_mock.mb.go
@@ -3,6 +3,7 @@ package gossiptopics
 
 import (
 	"github.com/orbs-network/go-mock"
+	"context"
 )
 
 /////////////////////////////////////////////////////////////////////////////
@@ -12,8 +13,8 @@ type MockLeanHelix struct {
 	mock.Mock
 }
 
-func (s *MockLeanHelix) SendLeanHelixPrePrepare(input *LeanHelixPrePrepareInput) (*EmptyOutput, error) {
-	ret := s.Called(input)
+func (s *MockLeanHelix) SendLeanHelixPrePrepare(ctx context.Context, input *LeanHelixPrePrepareInput) (*EmptyOutput, error) {
+	ret := s.Called(ctx, input)
 	if out := ret.Get(0); out != nil {
 		return out.(*EmptyOutput), ret.Error(1)
 	} else {
@@ -21,8 +22,8 @@ func (s *MockLeanHelix) SendLeanHelixPrePrepare(input *LeanHelixPrePrepareInput)
 	}
 }
 
-func (s *MockLeanHelix) SendLeanHelixPrepare(input *LeanHelixPrepareInput) (*EmptyOutput, error) {
-	ret := s.Called(input)
+func (s *MockLeanHelix) SendLeanHelixPrepare(ctx context.Context, input *LeanHelixPrepareInput) (*EmptyOutput, error) {
+	ret := s.Called(ctx, input)
 	if out := ret.Get(0); out != nil {
 		return out.(*EmptyOutput), ret.Error(1)
 	} else {
@@ -30,8 +31,8 @@ func (s *MockLeanHelix) SendLeanHelixPrepare(input *LeanHelixPrepareInput) (*Emp
 	}
 }
 
-func (s *MockLeanHelix) SendLeanHelixCommit(input *LeanHelixCommitInput) (*EmptyOutput, error) {
-	ret := s.Called(input)
+func (s *MockLeanHelix) SendLeanHelixCommit(ctx context.Context, input *LeanHelixCommitInput) (*EmptyOutput, error) {
+	ret := s.Called(ctx, input)
 	if out := ret.Get(0); out != nil {
 		return out.(*EmptyOutput), ret.Error(1)
 	} else {
@@ -39,8 +40,8 @@ func (s *MockLeanHelix) SendLeanHelixCommit(input *LeanHelixCommitInput) (*Empty
 	}
 }
 
-func (s *MockLeanHelix) SendLeanHelixViewChange(input *LeanHelixViewChangeInput) (*EmptyOutput, error) {
-	ret := s.Called(input)
+func (s *MockLeanHelix) SendLeanHelixViewChange(ctx context.Context, input *LeanHelixViewChangeInput) (*EmptyOutput, error) {
+	ret := s.Called(ctx, input)
 	if out := ret.Get(0); out != nil {
 		return out.(*EmptyOutput), ret.Error(1)
 	} else {
@@ -48,8 +49,8 @@ func (s *MockLeanHelix) SendLeanHelixViewChange(input *LeanHelixViewChangeInput)
 	}
 }
 
-func (s *MockLeanHelix) SendLeanHelixNewView(input *LeanHelixNewViewInput) (*EmptyOutput, error) {
-	ret := s.Called(input)
+func (s *MockLeanHelix) SendLeanHelixNewView(ctx context.Context, input *LeanHelixNewViewInput) (*EmptyOutput, error) {
+	ret := s.Called(ctx, input)
 	if out := ret.Get(0); out != nil {
 		return out.(*EmptyOutput), ret.Error(1)
 	} else {
@@ -68,8 +69,8 @@ type MockLeanHelixHandler struct {
 	mock.Mock
 }
 
-func (s *MockLeanHelixHandler) HandleLeanHelixPrePrepare(input *LeanHelixPrePrepareInput) (*EmptyOutput, error) {
-	ret := s.Called(input)
+func (s *MockLeanHelixHandler) HandleLeanHelixPrePrepare(ctx context.Context, input *LeanHelixPrePrepareInput) (*EmptyOutput, error) {
+	ret := s.Called(ctx, input)
 	if out := ret.Get(0); out != nil {
 		return out.(*EmptyOutput), ret.Error(1)
 	} else {
@@ -77,8 +78,8 @@ func (s *MockLeanHelixHandler) HandleLeanHelixPrePrepare(input *LeanHelixPrePrep
 	}
 }
 
-func (s *MockLeanHelixHandler) HandleLeanHelixPrepare(input *LeanHelixPrepareInput) (*EmptyOutput, error) {
-	ret := s.Called(input)
+func (s *MockLeanHelixHandler) HandleLeanHelixPrepare(ctx context.Context, input *LeanHelixPrepareInput) (*EmptyOutput, error) {
+	ret := s.Called(ctx, input)
 	if out := ret.Get(0); out != nil {
 		return out.(*EmptyOutput), ret.Error(1)
 	} else {
@@ -86,8 +87,8 @@ func (s *MockLeanHelixHandler) HandleLeanHelixPrepare(input *LeanHelixPrepareInp
 	}
 }
 
-func (s *MockLeanHelixHandler) HandleLeanHelixCommit(input *LeanHelixCommitInput) (*EmptyOutput, error) {
-	ret := s.Called(input)
+func (s *MockLeanHelixHandler) HandleLeanHelixCommit(ctx context.Context, input *LeanHelixCommitInput) (*EmptyOutput, error) {
+	ret := s.Called(ctx, input)
 	if out := ret.Get(0); out != nil {
 		return out.(*EmptyOutput), ret.Error(1)
 	} else {
@@ -95,8 +96,8 @@ func (s *MockLeanHelixHandler) HandleLeanHelixCommit(input *LeanHelixCommitInput
 	}
 }
 
-func (s *MockLeanHelixHandler) HandleLeanHelixViewChange(input *LeanHelixViewChangeInput) (*EmptyOutput, error) {
-	ret := s.Called(input)
+func (s *MockLeanHelixHandler) HandleLeanHelixViewChange(ctx context.Context, input *LeanHelixViewChangeInput) (*EmptyOutput, error) {
+	ret := s.Called(ctx, input)
 	if out := ret.Get(0); out != nil {
 		return out.(*EmptyOutput), ret.Error(1)
 	} else {
@@ -104,8 +105,8 @@ func (s *MockLeanHelixHandler) HandleLeanHelixViewChange(input *LeanHelixViewCha
 	}
 }
 
-func (s *MockLeanHelixHandler) HandleLeanHelixNewView(input *LeanHelixNewViewInput) (*EmptyOutput, error) {
-	ret := s.Called(input)
+func (s *MockLeanHelixHandler) HandleLeanHelixNewView(ctx context.Context, input *LeanHelixNewViewInput) (*EmptyOutput, error) {
+	ret := s.Called(ctx, input)
 	if out := ret.Get(0); out != nil {
 		return out.(*EmptyOutput), ret.Error(1)
 	} else {

--- a/types/go/services/gossiptopics/lean_helix_mock.mb.go
+++ b/types/go/services/gossiptopics/lean_helix_mock.mb.go
@@ -1,4 +1,4 @@
-// AUTO GENERATED FILE (by membufc proto compiler v0.0.19)
+// AUTO GENERATED FILE (by membufc proto compiler v0.0.20)
 package gossiptopics
 
 import (

--- a/types/go/services/gossiptopics/transaction_relay.mb.go
+++ b/types/go/services/gossiptopics/transaction_relay.mb.go
@@ -1,4 +1,4 @@
-// AUTO GENERATED FILE (by membufc proto compiler v0.0.19)
+// AUTO GENERATED FILE (by membufc proto compiler v0.0.20)
 package gossiptopics
 
 import (

--- a/types/go/services/gossiptopics/transaction_relay.mb.go
+++ b/types/go/services/gossiptopics/transaction_relay.mb.go
@@ -3,6 +3,7 @@ package gossiptopics
 
 import (
 	"fmt"
+	"context"
 	"github.com/orbs-network/orbs-spec/types/go/protocol/gossipmessages"
 )
 
@@ -10,7 +11,7 @@ import (
 // service TransactionRelay
 
 type TransactionRelay interface {
-	BroadcastForwardedTransactions(input *ForwardedTransactionsInput) (*EmptyOutput, error)
+	BroadcastForwardedTransactions(ctx context.Context, input *ForwardedTransactionsInput) (*EmptyOutput, error)
 	RegisterTransactionRelayHandler(handler TransactionRelayHandler)
 }
 
@@ -18,7 +19,7 @@ type TransactionRelay interface {
 // service TransactionRelayHandler
 
 type TransactionRelayHandler interface {
-	HandleForwardedTransactions(input *ForwardedTransactionsInput) (*EmptyOutput, error)
+	HandleForwardedTransactions(ctx context.Context, input *ForwardedTransactionsInput) (*EmptyOutput, error)
 }
 
 /////////////////////////////////////////////////////////////////////////////

--- a/types/go/services/gossiptopics/transaction_relay_mock.mb.go
+++ b/types/go/services/gossiptopics/transaction_relay_mock.mb.go
@@ -3,6 +3,7 @@ package gossiptopics
 
 import (
 	"github.com/orbs-network/go-mock"
+	"context"
 )
 
 /////////////////////////////////////////////////////////////////////////////
@@ -12,8 +13,8 @@ type MockTransactionRelay struct {
 	mock.Mock
 }
 
-func (s *MockTransactionRelay) BroadcastForwardedTransactions(input *ForwardedTransactionsInput) (*EmptyOutput, error) {
-	ret := s.Called(input)
+func (s *MockTransactionRelay) BroadcastForwardedTransactions(ctx context.Context, input *ForwardedTransactionsInput) (*EmptyOutput, error) {
+	ret := s.Called(ctx, input)
 	if out := ret.Get(0); out != nil {
 		return out.(*EmptyOutput), ret.Error(1)
 	} else {
@@ -32,8 +33,8 @@ type MockTransactionRelayHandler struct {
 	mock.Mock
 }
 
-func (s *MockTransactionRelayHandler) HandleForwardedTransactions(input *ForwardedTransactionsInput) (*EmptyOutput, error) {
-	ret := s.Called(input)
+func (s *MockTransactionRelayHandler) HandleForwardedTransactions(ctx context.Context, input *ForwardedTransactionsInput) (*EmptyOutput, error) {
+	ret := s.Called(ctx, input)
 	if out := ret.Get(0); out != nil {
 		return out.(*EmptyOutput), ret.Error(1)
 	} else {

--- a/types/go/services/gossiptopics/transaction_relay_mock.mb.go
+++ b/types/go/services/gossiptopics/transaction_relay_mock.mb.go
@@ -1,4 +1,4 @@
-// AUTO GENERATED FILE (by membufc proto compiler v0.0.19)
+// AUTO GENERATED FILE (by membufc proto compiler v0.0.20)
 package gossiptopics
 
 import (

--- a/types/go/services/handlers/consensus_blocks.mb.go
+++ b/types/go/services/handlers/consensus_blocks.mb.go
@@ -3,6 +3,7 @@ package handlers
 
 import (
 	"fmt"
+	"context"
 	"github.com/orbs-network/orbs-spec/types/go/protocol"
 )
 
@@ -10,7 +11,7 @@ import (
 // service ConsensusBlocksHandler
 
 type ConsensusBlocksHandler interface {
-	HandleBlockConsensus(input *HandleBlockConsensusInput) (*HandleBlockConsensusOutput, error)
+	HandleBlockConsensus(ctx context.Context, input *HandleBlockConsensusInput) (*HandleBlockConsensusOutput, error)
 }
 
 /////////////////////////////////////////////////////////////////////////////

--- a/types/go/services/handlers/consensus_blocks.mb.go
+++ b/types/go/services/handlers/consensus_blocks.mb.go
@@ -1,4 +1,4 @@
-// AUTO GENERATED FILE (by membufc proto compiler v0.0.19)
+// AUTO GENERATED FILE (by membufc proto compiler v0.0.20)
 package handlers
 
 import (

--- a/types/go/services/handlers/consensus_blocks_mock.mb.go
+++ b/types/go/services/handlers/consensus_blocks_mock.mb.go
@@ -1,4 +1,4 @@
-// AUTO GENERATED FILE (by membufc proto compiler v0.0.19)
+// AUTO GENERATED FILE (by membufc proto compiler v0.0.20)
 package handlers
 
 import (

--- a/types/go/services/handlers/consensus_blocks_mock.mb.go
+++ b/types/go/services/handlers/consensus_blocks_mock.mb.go
@@ -3,6 +3,7 @@ package handlers
 
 import (
 	"github.com/orbs-network/go-mock"
+	"context"
 )
 
 /////////////////////////////////////////////////////////////////////////////
@@ -12,8 +13,8 @@ type MockConsensusBlocksHandler struct {
 	mock.Mock
 }
 
-func (s *MockConsensusBlocksHandler) HandleBlockConsensus(input *HandleBlockConsensusInput) (*HandleBlockConsensusOutput, error) {
-	ret := s.Called(input)
+func (s *MockConsensusBlocksHandler) HandleBlockConsensus(ctx context.Context, input *HandleBlockConsensusInput) (*HandleBlockConsensusOutput, error) {
+	ret := s.Called(ctx, input)
 	if out := ret.Get(0); out != nil {
 		return out.(*HandleBlockConsensusOutput), ret.Error(1)
 	} else {

--- a/types/go/services/handlers/contract_sdk_call.mb.go
+++ b/types/go/services/handlers/contract_sdk_call.mb.go
@@ -1,4 +1,4 @@
-// AUTO GENERATED FILE (by membufc proto compiler v0.0.19)
+// AUTO GENERATED FILE (by membufc proto compiler v0.0.20)
 package handlers
 
 import (

--- a/types/go/services/handlers/contract_sdk_call.mb.go
+++ b/types/go/services/handlers/contract_sdk_call.mb.go
@@ -3,6 +3,7 @@ package handlers
 
 import (
 	"fmt"
+	"context"
 	"github.com/orbs-network/orbs-spec/types/go/primitives"
 	"github.com/orbs-network/orbs-spec/types/go/protocol"
 )
@@ -11,7 +12,7 @@ import (
 // service ContractSdkCallHandler
 
 type ContractSdkCallHandler interface {
-	HandleSdkCall(input *HandleSdkCallInput) (*HandleSdkCallOutput, error)
+	HandleSdkCall(ctx context.Context, input *HandleSdkCallInput) (*HandleSdkCallOutput, error)
 }
 
 /////////////////////////////////////////////////////////////////////////////

--- a/types/go/services/handlers/contract_sdk_call_mock.mb.go
+++ b/types/go/services/handlers/contract_sdk_call_mock.mb.go
@@ -3,6 +3,7 @@ package handlers
 
 import (
 	"github.com/orbs-network/go-mock"
+	"context"
 )
 
 /////////////////////////////////////////////////////////////////////////////
@@ -12,8 +13,8 @@ type MockContractSdkCallHandler struct {
 	mock.Mock
 }
 
-func (s *MockContractSdkCallHandler) HandleSdkCall(input *HandleSdkCallInput) (*HandleSdkCallOutput, error) {
-	ret := s.Called(input)
+func (s *MockContractSdkCallHandler) HandleSdkCall(ctx context.Context, input *HandleSdkCallInput) (*HandleSdkCallOutput, error) {
+	ret := s.Called(ctx, input)
 	if out := ret.Get(0); out != nil {
 		return out.(*HandleSdkCallOutput), ret.Error(1)
 	} else {

--- a/types/go/services/handlers/contract_sdk_call_mock.mb.go
+++ b/types/go/services/handlers/contract_sdk_call_mock.mb.go
@@ -1,4 +1,4 @@
-// AUTO GENERATED FILE (by membufc proto compiler v0.0.19)
+// AUTO GENERATED FILE (by membufc proto compiler v0.0.20)
 package handlers
 
 import (

--- a/types/go/services/handlers/transaction_results.mb.go
+++ b/types/go/services/handlers/transaction_results.mb.go
@@ -3,6 +3,7 @@ package handlers
 
 import (
 	"fmt"
+	"context"
 	"github.com/orbs-network/orbs-spec/types/go/primitives"
 	"github.com/orbs-network/orbs-spec/types/go/protocol"
 )
@@ -11,8 +12,8 @@ import (
 // service TransactionResultsHandler
 
 type TransactionResultsHandler interface {
-	HandleTransactionResults(input *HandleTransactionResultsInput) (*HandleTransactionResultsOutput, error)
-	HandleTransactionError(input *HandleTransactionErrorInput) (*HandleTransactionErrorOutput, error)
+	HandleTransactionResults(ctx context.Context, input *HandleTransactionResultsInput) (*HandleTransactionResultsOutput, error)
+	HandleTransactionError(ctx context.Context, input *HandleTransactionErrorInput) (*HandleTransactionErrorOutput, error)
 }
 
 /////////////////////////////////////////////////////////////////////////////

--- a/types/go/services/handlers/transaction_results.mb.go
+++ b/types/go/services/handlers/transaction_results.mb.go
@@ -1,4 +1,4 @@
-// AUTO GENERATED FILE (by membufc proto compiler v0.0.19)
+// AUTO GENERATED FILE (by membufc proto compiler v0.0.20)
 package handlers
 
 import (

--- a/types/go/services/handlers/transaction_results_mock.mb.go
+++ b/types/go/services/handlers/transaction_results_mock.mb.go
@@ -1,4 +1,4 @@
-// AUTO GENERATED FILE (by membufc proto compiler v0.0.19)
+// AUTO GENERATED FILE (by membufc proto compiler v0.0.20)
 package handlers
 
 import (

--- a/types/go/services/handlers/transaction_results_mock.mb.go
+++ b/types/go/services/handlers/transaction_results_mock.mb.go
@@ -3,6 +3,7 @@ package handlers
 
 import (
 	"github.com/orbs-network/go-mock"
+	"context"
 )
 
 /////////////////////////////////////////////////////////////////////////////
@@ -12,8 +13,8 @@ type MockTransactionResultsHandler struct {
 	mock.Mock
 }
 
-func (s *MockTransactionResultsHandler) HandleTransactionResults(input *HandleTransactionResultsInput) (*HandleTransactionResultsOutput, error) {
-	ret := s.Called(input)
+func (s *MockTransactionResultsHandler) HandleTransactionResults(ctx context.Context, input *HandleTransactionResultsInput) (*HandleTransactionResultsOutput, error) {
+	ret := s.Called(ctx, input)
 	if out := ret.Get(0); out != nil {
 		return out.(*HandleTransactionResultsOutput), ret.Error(1)
 	} else {
@@ -21,8 +22,8 @@ func (s *MockTransactionResultsHandler) HandleTransactionResults(input *HandleTr
 	}
 }
 
-func (s *MockTransactionResultsHandler) HandleTransactionError(input *HandleTransactionErrorInput) (*HandleTransactionErrorOutput, error) {
-	ret := s.Called(input)
+func (s *MockTransactionResultsHandler) HandleTransactionError(ctx context.Context, input *HandleTransactionErrorInput) (*HandleTransactionErrorOutput, error) {
+	ret := s.Called(ctx, input)
 	if out := ret.Get(0); out != nil {
 		return out.(*HandleTransactionErrorOutput), ret.Error(1)
 	} else {

--- a/types/go/services/processor.mb.go
+++ b/types/go/services/processor.mb.go
@@ -1,4 +1,4 @@
-// AUTO GENERATED FILE (by membufc proto compiler v0.0.19)
+// AUTO GENERATED FILE (by membufc proto compiler v0.0.20)
 package services
 
 import (
@@ -28,14 +28,13 @@ type ProcessCallInput struct {
 	AccessScope protocol.ExecutionAccessScope
 	CallingPermissionScope protocol.ExecutionPermissionScope
 	CallingService primitives.ContractName
-	TransactionSigner *protocol.Signer
 }
 
 func (x *ProcessCallInput) String() string {
 	if x == nil {
 		return "<nil>"
 	}
-	return fmt.Sprintf("{ContextId:%s,ContractName:%s,MethodName:%s,InputArgumentArray:%s,AccessScope:%s,CallingPermissionScope:%s,CallingService:%s,TransactionSigner:%s,}", x.StringContextId(), x.StringContractName(), x.StringMethodName(), x.StringInputArgumentArray(), x.StringAccessScope(), x.StringCallingPermissionScope(), x.StringCallingService(), x.StringTransactionSigner())
+	return fmt.Sprintf("{ContextId:%s,ContractName:%s,MethodName:%s,InputArgumentArray:%s,AccessScope:%s,CallingPermissionScope:%s,CallingService:%s,}", x.StringContextId(), x.StringContractName(), x.StringMethodName(), x.StringInputArgumentArray(), x.StringAccessScope(), x.StringCallingPermissionScope(), x.StringCallingService())
 }
 
 func (x *ProcessCallInput) StringContextId() (res string) {
@@ -70,11 +69,6 @@ func (x *ProcessCallInput) StringCallingPermissionScope() (res string) {
 
 func (x *ProcessCallInput) StringCallingService() (res string) {
 	res = fmt.Sprintf("%s", x.CallingService)
-	return
-}
-
-func (x *ProcessCallInput) StringTransactionSigner() (res string) {
-	res = x.TransactionSigner.String()
 	return
 }
 

--- a/types/go/services/processor.mb.go
+++ b/types/go/services/processor.mb.go
@@ -3,6 +3,7 @@ package services
 
 import (
 	"fmt"
+	"context"
 	"github.com/orbs-network/orbs-spec/types/go/primitives"
 	"github.com/orbs-network/orbs-spec/types/go/protocol"
 	"github.com/orbs-network/orbs-spec/types/go/services/handlers"
@@ -12,8 +13,8 @@ import (
 // service Processor
 
 type Processor interface {
-	ProcessCall(input *ProcessCallInput) (*ProcessCallOutput, error)
-	GetContractInfo(input *GetContractInfoInput) (*GetContractInfoOutput, error)
+	ProcessCall(ctx context.Context, input *ProcessCallInput) (*ProcessCallOutput, error)
+	GetContractInfo(ctx context.Context, input *GetContractInfoInput) (*GetContractInfoOutput, error)
 	RegisterContractSdkCallHandler(handler handlers.ContractSdkCallHandler)
 }
 

--- a/types/go/services/processor_mock.mb.go
+++ b/types/go/services/processor_mock.mb.go
@@ -1,4 +1,4 @@
-// AUTO GENERATED FILE (by membufc proto compiler v0.0.19)
+// AUTO GENERATED FILE (by membufc proto compiler v0.0.20)
 package services
 
 import (

--- a/types/go/services/processor_mock.mb.go
+++ b/types/go/services/processor_mock.mb.go
@@ -3,6 +3,7 @@ package services
 
 import (
 	"github.com/orbs-network/go-mock"
+	"context"
 	"github.com/orbs-network/orbs-spec/types/go/services/handlers"
 )
 
@@ -13,8 +14,8 @@ type MockProcessor struct {
 	mock.Mock
 }
 
-func (s *MockProcessor) ProcessCall(input *ProcessCallInput) (*ProcessCallOutput, error) {
-	ret := s.Called(input)
+func (s *MockProcessor) ProcessCall(ctx context.Context, input *ProcessCallInput) (*ProcessCallOutput, error) {
+	ret := s.Called(ctx, input)
 	if out := ret.Get(0); out != nil {
 		return out.(*ProcessCallOutput), ret.Error(1)
 	} else {
@@ -22,8 +23,8 @@ func (s *MockProcessor) ProcessCall(input *ProcessCallInput) (*ProcessCallOutput
 	}
 }
 
-func (s *MockProcessor) GetContractInfo(input *GetContractInfoInput) (*GetContractInfoOutput, error) {
-	ret := s.Called(input)
+func (s *MockProcessor) GetContractInfo(ctx context.Context, input *GetContractInfoInput) (*GetContractInfoOutput, error) {
+	ret := s.Called(ctx, input)
 	if out := ret.Get(0); out != nil {
 		return out.(*GetContractInfoOutput), ret.Error(1)
 	} else {

--- a/types/go/services/public_api.mb.go
+++ b/types/go/services/public_api.mb.go
@@ -1,4 +1,4 @@
-// AUTO GENERATED FILE (by membufc proto compiler v0.0.19)
+// AUTO GENERATED FILE (by membufc proto compiler v0.0.20)
 package services
 
 import (

--- a/types/go/services/public_api.mb.go
+++ b/types/go/services/public_api.mb.go
@@ -3,6 +3,7 @@ package services
 
 import (
 	"fmt"
+	"context"
 	"github.com/orbs-network/orbs-spec/types/go/protocol/client"
 	"github.com/orbs-network/orbs-spec/types/go/services/handlers"
 )
@@ -12,9 +13,9 @@ import (
 
 type PublicApi interface {
 	handlers.TransactionResultsHandler
-	SendTransaction(input *SendTransactionInput) (*SendTransactionOutput, error)
-	CallMethod(input *CallMethodInput) (*CallMethodOutput, error)
-	GetTransactionStatus(input *GetTransactionStatusInput) (*GetTransactionStatusOutput, error)
+	SendTransaction(ctx context.Context, input *SendTransactionInput) (*SendTransactionOutput, error)
+	CallMethod(ctx context.Context, input *CallMethodInput) (*CallMethodOutput, error)
+	GetTransactionStatus(ctx context.Context, input *GetTransactionStatusInput) (*GetTransactionStatusOutput, error)
 }
 
 /////////////////////////////////////////////////////////////////////////////

--- a/types/go/services/public_api_mock.mb.go
+++ b/types/go/services/public_api_mock.mb.go
@@ -1,4 +1,4 @@
-// AUTO GENERATED FILE (by membufc proto compiler v0.0.19)
+// AUTO GENERATED FILE (by membufc proto compiler v0.0.20)
 package services
 
 import (

--- a/types/go/services/public_api_mock.mb.go
+++ b/types/go/services/public_api_mock.mb.go
@@ -3,6 +3,7 @@ package services
 
 import (
 	"github.com/orbs-network/go-mock"
+	"context"
 	"github.com/orbs-network/orbs-spec/types/go/services/handlers"
 )
 
@@ -14,8 +15,8 @@ type MockPublicApi struct {
 	handlers.MockTransactionResultsHandler
 }
 
-func (s *MockPublicApi) SendTransaction(input *SendTransactionInput) (*SendTransactionOutput, error) {
-	ret := s.Called(input)
+func (s *MockPublicApi) SendTransaction(ctx context.Context, input *SendTransactionInput) (*SendTransactionOutput, error) {
+	ret := s.Called(ctx, input)
 	if out := ret.Get(0); out != nil {
 		return out.(*SendTransactionOutput), ret.Error(1)
 	} else {
@@ -23,8 +24,8 @@ func (s *MockPublicApi) SendTransaction(input *SendTransactionInput) (*SendTrans
 	}
 }
 
-func (s *MockPublicApi) CallMethod(input *CallMethodInput) (*CallMethodOutput, error) {
-	ret := s.Called(input)
+func (s *MockPublicApi) CallMethod(ctx context.Context, input *CallMethodInput) (*CallMethodOutput, error) {
+	ret := s.Called(ctx, input)
 	if out := ret.Get(0); out != nil {
 		return out.(*CallMethodOutput), ret.Error(1)
 	} else {
@@ -32,8 +33,8 @@ func (s *MockPublicApi) CallMethod(input *CallMethodInput) (*CallMethodOutput, e
 	}
 }
 
-func (s *MockPublicApi) GetTransactionStatus(input *GetTransactionStatusInput) (*GetTransactionStatusOutput, error) {
-	ret := s.Called(input)
+func (s *MockPublicApi) GetTransactionStatus(ctx context.Context, input *GetTransactionStatusInput) (*GetTransactionStatusOutput, error) {
+	ret := s.Called(ctx, input)
 	if out := ret.Get(0); out != nil {
 		return out.(*GetTransactionStatusOutput), ret.Error(1)
 	} else {

--- a/types/go/services/state_storage.mb.go
+++ b/types/go/services/state_storage.mb.go
@@ -1,4 +1,4 @@
-// AUTO GENERATED FILE (by membufc proto compiler v0.0.19)
+// AUTO GENERATED FILE (by membufc proto compiler v0.0.20)
 package services
 
 import (

--- a/types/go/services/state_storage.mb.go
+++ b/types/go/services/state_storage.mb.go
@@ -3,6 +3,7 @@ package services
 
 import (
 	"fmt"
+	"context"
 	"github.com/orbs-network/orbs-spec/types/go/primitives"
 	"github.com/orbs-network/orbs-spec/types/go/protocol"
 )
@@ -11,10 +12,10 @@ import (
 // service StateStorage
 
 type StateStorage interface {
-	CommitStateDiff(input *CommitStateDiffInput) (*CommitStateDiffOutput, error)
-	ReadKeys(input *ReadKeysInput) (*ReadKeysOutput, error)
-	GetStateStorageBlockHeight(input *GetStateStorageBlockHeightInput) (*GetStateStorageBlockHeightOutput, error)
-	GetStateHash(input *GetStateHashInput) (*GetStateHashOutput, error)
+	CommitStateDiff(ctx context.Context, input *CommitStateDiffInput) (*CommitStateDiffOutput, error)
+	ReadKeys(ctx context.Context, input *ReadKeysInput) (*ReadKeysOutput, error)
+	GetStateStorageBlockHeight(ctx context.Context, input *GetStateStorageBlockHeightInput) (*GetStateStorageBlockHeightOutput, error)
+	GetStateHash(ctx context.Context, input *GetStateHashInput) (*GetStateHashOutput, error)
 }
 
 /////////////////////////////////////////////////////////////////////////////

--- a/types/go/services/state_storage_mock.mb.go
+++ b/types/go/services/state_storage_mock.mb.go
@@ -1,4 +1,4 @@
-// AUTO GENERATED FILE (by membufc proto compiler v0.0.19)
+// AUTO GENERATED FILE (by membufc proto compiler v0.0.20)
 package services
 
 import (

--- a/types/go/services/state_storage_mock.mb.go
+++ b/types/go/services/state_storage_mock.mb.go
@@ -3,6 +3,7 @@ package services
 
 import (
 	"github.com/orbs-network/go-mock"
+	"context"
 )
 
 /////////////////////////////////////////////////////////////////////////////
@@ -12,8 +13,8 @@ type MockStateStorage struct {
 	mock.Mock
 }
 
-func (s *MockStateStorage) CommitStateDiff(input *CommitStateDiffInput) (*CommitStateDiffOutput, error) {
-	ret := s.Called(input)
+func (s *MockStateStorage) CommitStateDiff(ctx context.Context, input *CommitStateDiffInput) (*CommitStateDiffOutput, error) {
+	ret := s.Called(ctx, input)
 	if out := ret.Get(0); out != nil {
 		return out.(*CommitStateDiffOutput), ret.Error(1)
 	} else {
@@ -21,8 +22,8 @@ func (s *MockStateStorage) CommitStateDiff(input *CommitStateDiffInput) (*Commit
 	}
 }
 
-func (s *MockStateStorage) ReadKeys(input *ReadKeysInput) (*ReadKeysOutput, error) {
-	ret := s.Called(input)
+func (s *MockStateStorage) ReadKeys(ctx context.Context, input *ReadKeysInput) (*ReadKeysOutput, error) {
+	ret := s.Called(ctx, input)
 	if out := ret.Get(0); out != nil {
 		return out.(*ReadKeysOutput), ret.Error(1)
 	} else {
@@ -30,8 +31,8 @@ func (s *MockStateStorage) ReadKeys(input *ReadKeysInput) (*ReadKeysOutput, erro
 	}
 }
 
-func (s *MockStateStorage) GetStateStorageBlockHeight(input *GetStateStorageBlockHeightInput) (*GetStateStorageBlockHeightOutput, error) {
-	ret := s.Called(input)
+func (s *MockStateStorage) GetStateStorageBlockHeight(ctx context.Context, input *GetStateStorageBlockHeightInput) (*GetStateStorageBlockHeightOutput, error) {
+	ret := s.Called(ctx, input)
 	if out := ret.Get(0); out != nil {
 		return out.(*GetStateStorageBlockHeightOutput), ret.Error(1)
 	} else {
@@ -39,8 +40,8 @@ func (s *MockStateStorage) GetStateStorageBlockHeight(input *GetStateStorageBloc
 	}
 }
 
-func (s *MockStateStorage) GetStateHash(input *GetStateHashInput) (*GetStateHashOutput, error) {
-	ret := s.Called(input)
+func (s *MockStateStorage) GetStateHash(ctx context.Context, input *GetStateHashInput) (*GetStateHashOutput, error) {
+	ret := s.Called(ctx, input)
 	if out := ret.Get(0); out != nil {
 		return out.(*GetStateHashOutput), ret.Error(1)
 	} else {

--- a/types/go/services/transaction_pool.mb.go
+++ b/types/go/services/transaction_pool.mb.go
@@ -1,4 +1,4 @@
-// AUTO GENERATED FILE (by membufc proto compiler v0.0.19)
+// AUTO GENERATED FILE (by membufc proto compiler v0.0.20)
 package services
 
 import (

--- a/types/go/services/transaction_pool.mb.go
+++ b/types/go/services/transaction_pool.mb.go
@@ -3,6 +3,7 @@ package services
 
 import (
 	"fmt"
+	"context"
 	"github.com/orbs-network/orbs-spec/types/go/primitives"
 	"github.com/orbs-network/orbs-spec/types/go/protocol"
 	"github.com/orbs-network/orbs-spec/types/go/services/gossiptopics"
@@ -14,11 +15,11 @@ import (
 
 type TransactionPool interface {
 	gossiptopics.TransactionRelayHandler
-	AddNewTransaction(input *AddNewTransactionInput) (*AddNewTransactionOutput, error)
-	GetCommittedTransactionReceipt(input *GetCommittedTransactionReceiptInput) (*GetCommittedTransactionReceiptOutput, error)
-	GetTransactionsForOrdering(input *GetTransactionsForOrderingInput) (*GetTransactionsForOrderingOutput, error)
-	ValidateTransactionsForOrdering(input *ValidateTransactionsForOrderingInput) (*ValidateTransactionsForOrderingOutput, error)
-	CommitTransactionReceipts(input *CommitTransactionReceiptsInput) (*CommitTransactionReceiptsOutput, error)
+	AddNewTransaction(ctx context.Context, input *AddNewTransactionInput) (*AddNewTransactionOutput, error)
+	GetCommittedTransactionReceipt(ctx context.Context, input *GetCommittedTransactionReceiptInput) (*GetCommittedTransactionReceiptOutput, error)
+	GetTransactionsForOrdering(ctx context.Context, input *GetTransactionsForOrderingInput) (*GetTransactionsForOrderingOutput, error)
+	ValidateTransactionsForOrdering(ctx context.Context, input *ValidateTransactionsForOrderingInput) (*ValidateTransactionsForOrderingOutput, error)
+	CommitTransactionReceipts(ctx context.Context, input *CommitTransactionReceiptsInput) (*CommitTransactionReceiptsOutput, error)
 	RegisterTransactionResultsHandler(handler handlers.TransactionResultsHandler)
 }
 

--- a/types/go/services/transaction_pool_mock.mb.go
+++ b/types/go/services/transaction_pool_mock.mb.go
@@ -1,4 +1,4 @@
-// AUTO GENERATED FILE (by membufc proto compiler v0.0.19)
+// AUTO GENERATED FILE (by membufc proto compiler v0.0.20)
 package services
 
 import (

--- a/types/go/services/transaction_pool_mock.mb.go
+++ b/types/go/services/transaction_pool_mock.mb.go
@@ -3,6 +3,7 @@ package services
 
 import (
 	"github.com/orbs-network/go-mock"
+	"context"
 	"github.com/orbs-network/orbs-spec/types/go/services/gossiptopics"
 	"github.com/orbs-network/orbs-spec/types/go/services/handlers"
 )
@@ -15,8 +16,8 @@ type MockTransactionPool struct {
 	gossiptopics.MockTransactionRelayHandler
 }
 
-func (s *MockTransactionPool) AddNewTransaction(input *AddNewTransactionInput) (*AddNewTransactionOutput, error) {
-	ret := s.Called(input)
+func (s *MockTransactionPool) AddNewTransaction(ctx context.Context, input *AddNewTransactionInput) (*AddNewTransactionOutput, error) {
+	ret := s.Called(ctx, input)
 	if out := ret.Get(0); out != nil {
 		return out.(*AddNewTransactionOutput), ret.Error(1)
 	} else {
@@ -24,8 +25,8 @@ func (s *MockTransactionPool) AddNewTransaction(input *AddNewTransactionInput) (
 	}
 }
 
-func (s *MockTransactionPool) GetCommittedTransactionReceipt(input *GetCommittedTransactionReceiptInput) (*GetCommittedTransactionReceiptOutput, error) {
-	ret := s.Called(input)
+func (s *MockTransactionPool) GetCommittedTransactionReceipt(ctx context.Context, input *GetCommittedTransactionReceiptInput) (*GetCommittedTransactionReceiptOutput, error) {
+	ret := s.Called(ctx, input)
 	if out := ret.Get(0); out != nil {
 		return out.(*GetCommittedTransactionReceiptOutput), ret.Error(1)
 	} else {
@@ -33,8 +34,8 @@ func (s *MockTransactionPool) GetCommittedTransactionReceipt(input *GetCommitted
 	}
 }
 
-func (s *MockTransactionPool) GetTransactionsForOrdering(input *GetTransactionsForOrderingInput) (*GetTransactionsForOrderingOutput, error) {
-	ret := s.Called(input)
+func (s *MockTransactionPool) GetTransactionsForOrdering(ctx context.Context, input *GetTransactionsForOrderingInput) (*GetTransactionsForOrderingOutput, error) {
+	ret := s.Called(ctx, input)
 	if out := ret.Get(0); out != nil {
 		return out.(*GetTransactionsForOrderingOutput), ret.Error(1)
 	} else {
@@ -42,8 +43,8 @@ func (s *MockTransactionPool) GetTransactionsForOrdering(input *GetTransactionsF
 	}
 }
 
-func (s *MockTransactionPool) ValidateTransactionsForOrdering(input *ValidateTransactionsForOrderingInput) (*ValidateTransactionsForOrderingOutput, error) {
-	ret := s.Called(input)
+func (s *MockTransactionPool) ValidateTransactionsForOrdering(ctx context.Context, input *ValidateTransactionsForOrderingInput) (*ValidateTransactionsForOrderingOutput, error) {
+	ret := s.Called(ctx, input)
 	if out := ret.Get(0); out != nil {
 		return out.(*ValidateTransactionsForOrderingOutput), ret.Error(1)
 	} else {
@@ -51,8 +52,8 @@ func (s *MockTransactionPool) ValidateTransactionsForOrdering(input *ValidateTra
 	}
 }
 
-func (s *MockTransactionPool) CommitTransactionReceipts(input *CommitTransactionReceiptsInput) (*CommitTransactionReceiptsOutput, error) {
-	ret := s.Called(input)
+func (s *MockTransactionPool) CommitTransactionReceipts(ctx context.Context, input *CommitTransactionReceiptsInput) (*CommitTransactionReceiptsOutput, error) {
+	ret := s.Called(ctx, input)
 	if out := ret.Get(0); out != nil {
 		return out.(*CommitTransactionReceiptsOutput), ret.Error(1)
 	} else {

--- a/types/go/services/virtual_machine.mb.go
+++ b/types/go/services/virtual_machine.mb.go
@@ -1,4 +1,4 @@
-// AUTO GENERATED FILE (by membufc proto compiler v0.0.19)
+// AUTO GENERATED FILE (by membufc proto compiler v0.0.20)
 package services
 
 import (

--- a/types/go/services/virtual_machine.mb.go
+++ b/types/go/services/virtual_machine.mb.go
@@ -3,6 +3,7 @@ package services
 
 import (
 	"fmt"
+	"context"
 	"github.com/orbs-network/orbs-spec/types/go/protocol"
 	"github.com/orbs-network/orbs-spec/types/go/primitives"
 	"github.com/orbs-network/orbs-spec/types/go/services/handlers"
@@ -13,9 +14,9 @@ import (
 
 type VirtualMachine interface {
 	handlers.ContractSdkCallHandler
-	ProcessTransactionSet(input *ProcessTransactionSetInput) (*ProcessTransactionSetOutput, error)
-	RunLocalMethod(input *RunLocalMethodInput) (*RunLocalMethodOutput, error)
-	TransactionSetPreOrder(input *TransactionSetPreOrderInput) (*TransactionSetPreOrderOutput, error)
+	ProcessTransactionSet(ctx context.Context, input *ProcessTransactionSetInput) (*ProcessTransactionSetOutput, error)
+	RunLocalMethod(ctx context.Context, input *RunLocalMethodInput) (*RunLocalMethodOutput, error)
+	TransactionSetPreOrder(ctx context.Context, input *TransactionSetPreOrderInput) (*TransactionSetPreOrderOutput, error)
 }
 
 /////////////////////////////////////////////////////////////////////////////

--- a/types/go/services/virtual_machine_mock.mb.go
+++ b/types/go/services/virtual_machine_mock.mb.go
@@ -3,6 +3,7 @@ package services
 
 import (
 	"github.com/orbs-network/go-mock"
+	"context"
 	"github.com/orbs-network/orbs-spec/types/go/services/handlers"
 )
 
@@ -14,8 +15,8 @@ type MockVirtualMachine struct {
 	handlers.MockContractSdkCallHandler
 }
 
-func (s *MockVirtualMachine) ProcessTransactionSet(input *ProcessTransactionSetInput) (*ProcessTransactionSetOutput, error) {
-	ret := s.Called(input)
+func (s *MockVirtualMachine) ProcessTransactionSet(ctx context.Context, input *ProcessTransactionSetInput) (*ProcessTransactionSetOutput, error) {
+	ret := s.Called(ctx, input)
 	if out := ret.Get(0); out != nil {
 		return out.(*ProcessTransactionSetOutput), ret.Error(1)
 	} else {
@@ -23,8 +24,8 @@ func (s *MockVirtualMachine) ProcessTransactionSet(input *ProcessTransactionSetI
 	}
 }
 
-func (s *MockVirtualMachine) RunLocalMethod(input *RunLocalMethodInput) (*RunLocalMethodOutput, error) {
-	ret := s.Called(input)
+func (s *MockVirtualMachine) RunLocalMethod(ctx context.Context, input *RunLocalMethodInput) (*RunLocalMethodOutput, error) {
+	ret := s.Called(ctx, input)
 	if out := ret.Get(0); out != nil {
 		return out.(*RunLocalMethodOutput), ret.Error(1)
 	} else {
@@ -32,8 +33,8 @@ func (s *MockVirtualMachine) RunLocalMethod(input *RunLocalMethodInput) (*RunLoc
 	}
 }
 
-func (s *MockVirtualMachine) TransactionSetPreOrder(input *TransactionSetPreOrderInput) (*TransactionSetPreOrderOutput, error) {
-	ret := s.Called(input)
+func (s *MockVirtualMachine) TransactionSetPreOrder(ctx context.Context, input *TransactionSetPreOrderInput) (*TransactionSetPreOrderOutput, error) {
+	ret := s.Called(ctx, input)
 	if out := ret.Get(0); out != nil {
 		return out.(*TransactionSetPreOrderOutput), ret.Error(1)
 	} else {

--- a/types/go/services/virtual_machine_mock.mb.go
+++ b/types/go/services/virtual_machine_mock.mb.go
@@ -1,4 +1,4 @@
-// AUTO GENERATED FILE (by membufc proto compiler v0.0.19)
+// AUTO GENERATED FILE (by membufc proto compiler v0.0.20)
 package services
 
 import (


### PR DESCRIPTION
Added context to rpc calls; WARNING: *Do not update orbs-spec dep* in orbs-network-go before all compilation errors due to this change are resolved.