### PR TITLE
Remove lean helix specific messages because they are no longer visibl…

### DIFF
--- a/interfaces/protocol/consensus/lean_helix.proto
+++ b/interfaces/protocol/consensus/lean_helix.proto
@@ -6,14 +6,7 @@ import "../primitives/crypto.proto";
 import "../primitives/integers.proto";
 import "../primitives/protocol.proto";
 
-enum LeanHelixMessageType {
-    LEAN_HELIX_RESERVED = 0;
-    LEAN_HELIX_PRE_PREPARE = 1;
-    LEAN_HELIX_PREPARE = 2;
-    LEAN_HELIX_COMMIT = 3;
-    LEAN_HELIX_NEW_VIEW = 4;
-    LEAN_HELIX_VIEW_CHANGE = 5;
-}
+enum LeanHelixMessageType {}
 
 message LeanHelixBlockProof {
     LeanHelixBlockRef block_ref = 1;

--- a/types/go/protocol/consensus/lean_helix.mb.go
+++ b/types/go/protocol/consensus/lean_helix.mb.go
@@ -490,29 +490,10 @@ func (w *LeanHelixBlockRefBuilder) Build() *LeanHelixBlockRef {
 
 type LeanHelixMessageType uint16
 
-const (
-	LEAN_HELIX_RESERVED    LeanHelixMessageType = 0
-	LEAN_HELIX_PRE_PREPARE LeanHelixMessageType = 1
-	LEAN_HELIX_PREPARE     LeanHelixMessageType = 2
-	LEAN_HELIX_COMMIT      LeanHelixMessageType = 3
-	LEAN_HELIX_NEW_VIEW    LeanHelixMessageType = 4
-	LEAN_HELIX_VIEW_CHANGE LeanHelixMessageType = 5
-)
+const ()
 
 func (n LeanHelixMessageType) String() string {
 	switch n {
-	case LEAN_HELIX_RESERVED:
-		return "LEAN_HELIX_RESERVED"
-	case LEAN_HELIX_PRE_PREPARE:
-		return "LEAN_HELIX_PRE_PREPARE"
-	case LEAN_HELIX_PREPARE:
-		return "LEAN_HELIX_PREPARE"
-	case LEAN_HELIX_COMMIT:
-		return "LEAN_HELIX_COMMIT"
-	case LEAN_HELIX_NEW_VIEW:
-		return "LEAN_HELIX_NEW_VIEW"
-	case LEAN_HELIX_VIEW_CHANGE:
-		return "LEAN_HELIX_VIEW_CHANGE"
 	}
 	return "UNKNOWN"
 }


### PR DESCRIPTION
…e to orbs-network. They were moved to lean-helix-go repo spec instead.