### PR TITLE
minimal time between empty blocks

### DIFF
--- a/behaviors/config/services.md
+++ b/behaviors/config/services.md
@@ -56,8 +56,6 @@ Since the system must remain backwards compatible forever (able to audit the old
 
 ```json
 {
-  "minimal-block-transaction-num": "0",
-  "minimal-block-delay-sec": "0.5",
   "system-timestamp-allowed-jitter-sec": "2"
 }
 ```
@@ -75,7 +73,7 @@ Since the system must remain backwards compatible forever (able to audit the old
 
 ```json
 {
-  "block-sync-commit-timeout-sec": "8",
+  "block-sync-commit-timeout-empty-blocks-time": "4",
   "transaction-search-grace-sec": "5",
   "query-sync-grace-block-num": "0",
   "max-blocks-per-sync-batch": "1000",

--- a/behaviors/config/shared.md
+++ b/behaviors/config/shared.md
@@ -71,3 +71,11 @@ Since the system must remain backwards compatible forever (able to audit the old
   "query-grace-timeout-millis": "1000"
 }
 ```
+
+#### Cross services grace wait timeout
+
+```json
+{
+  "minimum-time-between-empty-blocks-sec": "10"
+}
+```

--- a/behaviors/services/block-storage.md
+++ b/behaviors/services/block-storage.md
@@ -47,7 +47,7 @@ Currently a single instance per virtual chain per node.
 #### Trigger
 * Endless loop which is continuously waiting for a trigger marking the node as out of sync.
 * The synchronization process is triggered upon:
-  * Too much time has passed without a commit with `CommitBlock`. Based on a [configurable](../config/services.md) timeout (eg. 8 sec).
+  * Too much time has passed without a commit with `CommitBlock`. Based on a [configurable](../config/services.md) number of periods of minimal time between empty blocks [configurable](../config/shared.md) 
   * During the Init flow.
 * Make sure no more than one synchronization process is active at any given time.
 

--- a/behaviors/services/consensus-context.md
+++ b/behaviors/services/consensus-context.md
@@ -42,11 +42,10 @@ Currently a single instance per virtual chain per node.
 * Get the block reference timestamp by reading the 64b unix timestamp.  
   * If the uinx timestamp is less or equal then the previous block timestamp, use previous block timestamp + 1 nano.
 
-#### Choose pending transactions
+#### Get pending transactions
 * Get pending transactions by calling `TransactionPool.GetTransactionsForOrdering`.
-  * If there are too little transactions to append (minimal block according to a [configurable](../config/services.md) amount):
-    * Wait [configurable](../config/services.md) time (eg. 0.5 sec) and retry once.
-    * If no transactions continue with an empty block (number of transactions is 0).
+  * If there are no valid transactions, the `TransactionPool` holds the response until tehre are transactions to send or timeout.
+  * If a response is returned with no transactions, build an empty block.
 
 #### Build Transactions block
 * Current protocol version (`0x1`).

--- a/behaviors/services/transaction-pool.md
+++ b/behaviors/services/transaction-pool.md
@@ -120,6 +120,10 @@ Currently a single instance per virtual chain per node.
     * If indeed local, update the registered public api service by calling its `HandleTransactionError`.
       * Provide block height and timestamp according to the last committed block.
 
+#### Check minimal number of valid transactions
+* Check that there are valid transactions 
+  * If there are no valid transactions, repeat the `GetTransactionsForOrdering` flow until reaching the threshold or reaching the ([configurable](../config/shared.md) minimal time between blocks.
+
 &nbsp;
 ## `ValidateTransactionsForOrdering` (method)
 


### PR DESCRIPTION
Moved the minimal time between empty blocks from the Consensus context to the TransactionPool.
* Removed the consensus context configuration of minimum transactions in block - there's no point to have a threshold != 0.

* Renamed and moved the minimal time configuration to the shared.md 
     "minimum-time-between-empty-blocks-sec": "10"

* Changed the block storage trigger for block sync to depend on a number of empty blocks time periods.
      "block-sync-commit-timeout-empty-blocks-time": "4",
