### PR TITLE
time based election

### DIFF
--- a/behaviors/v1_1/time-based-election-periods.md
+++ b/behaviors/v1_1/time-based-election-periods.md
@@ -8,9 +8,9 @@
   * 3 days starting from the last election time. 
   * Election block = the first Ethereum block with timestamp > Election time.
 * Delegation validity
-  * Delegations are considered for the election if the Delegation block timestamp < election time.
+  * Delegations are considered for the election if the Delegation block timestamp <= election time.
 * Election block height:
-  * The `election block number` is set to the first Ethereum block with timestamp >= election time.
+  * The `election block number` is set to the first Ethereum block with timestamp > election time.
 * Vote validity:
   * A vote is valid for an election if the vote block timestamp + 7 days <= election time.
 * Rewards:

--- a/behaviors/v1_1/time-based-election-periods.md
+++ b/behaviors/v1_1/time-based-election-periods.md
@@ -33,7 +33,7 @@
   * If current Ethereum block time < `FIRST_TIME_BASED_ELECTION` 
     * next election time = `FIRST_TIME_BASED_ELECTION`
   * Else
-    * next election time = `FIRST_TIME_BASED_ELECTION` + N x `ELECTION_PERIOD` such that next election time is less than the current Ethereum block time.
+    * next election time = `FIRST_TIME_BASED_ELECTION` + N x `ELECTION_PERIOD` such that next election time is after the current Ethereum block time.
   * Note: will be deprecated after the management chain implementation.  
 
 *General*

--- a/behaviors/v1_1/time-based-election-periods.md
+++ b/behaviors/v1_1/time-based-election-periods.md
@@ -27,7 +27,14 @@
   * Check validity by time instead of block height.
 * Rewards
   * Replace the factor with 365.24/3
-* APIs
+* Election schedule / first election
+  * The next election is the first election in the election schedule following the first time based election.
+  * Get the current Ethereum block time using `Ethereum.GetBlockTime()`
+  * If current Ethereum block time < `FIRST_TIME_BASED_ELECTION` 
+    * next election time = `FIRST_TIME_BASED_ELECTION`
+  * Else
+    * next election time = `FIRST_TIME_BASED_ELECTION` + N x `ELECTION_PERIOD` such that next election time is less than the current Ethereum block time.
+  * Note: will be deprecated after the management chain implementation.  
 
 *General*
 
@@ -40,7 +47,7 @@
   * getElectedValidatorsEthereumAddress() - as is
   * getCurrentEthereumBlockNumber() - as is
   * *getProcessingStartBlockNumber()* - deprecated, panic("Processing start time: ...")
-  * *getMirroringEndBlockNumber()* - deprecated, panic("MIrroring end time: ...")
+  * *getMirroringEndBlockNumber()* - deprecated, panic("Mirroring end time: ...")
   * *getCurrentElectionTime()* - New function
     * Returns the time of the election in process
   * *getNextElectionTime()* - New function

--- a/behaviors/v1_1/time-based-election-periods.md
+++ b/behaviors/v1_1/time-based-election-periods.md
@@ -1,0 +1,86 @@
+# Time based election period
+> Elections are set every 20,000 Ethereum blocks (targeting approximately 3 days) and a Guardian vote is valid for 45,500 (targeting approximately 7 days).
+> Recently the average Ethereum block time varies and continues increase is expected due to the difficulty bomb.
+> As a result, election times and rewards are less predictable.
+> The specification update changes the parameters to time based instead of number of blocks based.
+
+* Election time 
+  * 3 days starting from the last election time. 
+  * Election block = the first Ethereum block with timestamp > Election time.
+* Delegation validity
+  * Delegations are considered for the election if the Delegation block timestamp < election time.
+* Election block height:
+  * The `election block number` is set to the first Ethereum block with timestamp >= election time.
+* Vote validity:
+  * A vote is valid for an election if the vote block timestamp + 7 days <= election time.
+* Rewards:
+  * Calculated based on a fixed 3 days between elections, i.e. 365.24 / 3 Elections per year.
+
+# Feature impact
+## Elections contract impact
+* mirrorDelegation
+  * Check validity by time instead of block height.
+    * May maintain database by block number or timestamp.
+* Processing state machine
+  * Processing start determined by time - 2 hours after election time.
+* Vote recording 
+  * Check validity by time instead of block height.
+* Rewards
+  * Replace the factor with 365.24/3
+* APIs
+
+*General*
+
+  * getEffectiveElectionBlockNumber - as is
+  * *getCurrentElectionBlockNumber()* - deprecated, panic("Current election time: ...")
+  * *getNextElectionBlockNumber()* - deprecated, panic("Next election time: ...")
+  * *getElectionPeriod()* - deprecated, panic("Election period is % days")
+  * getNumberOfElections() - as is
+  * getElectedValidatorsOrbsAddress() - as is
+  * getElectedValidatorsEthereumAddress() - as is
+  * getCurrentEthereumBlockNumber() - as is
+  * *getProcessingStartBlockNumber()* - deprecated, panic("Processing start time: ...")
+  * *getMirroringEndBlockNumber()* - deprecated, panic("MIrroring end time: ...")
+  * *getCurrentElectionTime()* - New function
+    * Returns the time of the election in process
+  * *getNextElectionTime()* - New function
+    * Returns the time of the next election
+  * *getProcessingTime()* - New function
+    * Returns next the processing time
+
+*Extended Last Election Results* - as is
+
+*Historical data*
+  * getElectedValidatorsOrbsAddressByBlockHeight(orbs_block_height) - as is
+  * getElectedValidatorsEthereumAddressByBlockNumber(block_number) - as is
+  * getElectedValidatorsOrbsAddressByIndex(index) - as is
+  * getElectedValidatorsEthereumAddressByIndex(index) - as is
+  * getElectedValidatorsOrbsAddressByIndex(index) - as is
+  * getElectionEventBlockNumberByIndex(index) - as is
+  * getElectionResultsBlockHeightByIndex(index) - as is
+
+*Rewards* - as is
+       
+##  SDK / Crosschain connector new function
+
+### Ethereum.GetBlockTimeByNumber(uint32 blockNumber) : uint64 (epoch time)
+* Input: blockNumber
+  * If blockNumber > block number for finality, fail the call.
+* Output: the epoch time of the block (in seconds), for example GetEthereumBlockTime(7430000) = 1553411888
+* Usage: validity of mirrored delegation.
+
+### Ethereum.GetBlockNumberByTime(epoch_time : uint32) : uint32
+* Input: epoch time in sec
+  * If epoch_time < current time + ETHEREUM_FINALITY_TIME_COMPONENT, fail the call.
+* Output: 
+  * Returns the maximum Ethereum block number such that its timestamp < epoch_time.
+  * If result < block number for finality, fail the call.
+* Usage: retrieve the election block number.
+
+### Ethereum.GetBlockTime() : uint64 (epoch time)
+* Output: the epoch time of the current Ethereum block (the block for finality)
+* Usage: processing start (may be replaced by GetBlockNumber + GetBlockTimeByNumber, provided for completeness)
+
+## Voting UIs
+* Replace next election block with next election time.
+* Update vote validity for next election logic

--- a/interfaces/services/crosschain_connector.proto
+++ b/interfaces/services/crosschain_connector.proto
@@ -11,6 +11,9 @@ service CrosschainConnector {
     rpc EthereumCallContract (EthereumCallContractInput) returns (EthereumCallContractOutput);
     rpc EthereumGetTransactionLogs (EthereumGetTransactionLogsInput) returns (EthereumGetTransactionLogsOutput);
     rpc EthereumGetBlockNumber (EthereumGetBlockNumberInput) returns (EthereumGetBlockNumberOutput);
+    rpc EthereumGetBlockTime (EthereumGetBlockTimeInput) returns (EthereumGetBlockTimeOutput);
+    rpc EthereumGetBlockTimeByNumber (EthereumGetBlockTimeByNumberInput) returns (EthereumGetBlockTimeByNumberOutput);
+    rpc EthereumGetBlockNumberByTime (EthereumGetBlockNumberByTimeInput) returns (EthereumGetBlockNumberByTimeOutput);
 }
 
 message EthereumCallContractInput {
@@ -45,5 +48,31 @@ message EthereumGetBlockNumberInput {
 }
 
 message EthereumGetBlockNumberOutput {
+    uint64 ethereum_block_number = 1;
+}
+
+message EthereumGetBlockTimeByNumberInput {
+    primitives.timestamp_nano reference_timestamp = 1;
+    uint64 ethereum_block_number = 2;
+}
+
+message EthereumGetBlockTimeByNumberOutput {
+    primitives.timestamp_nano ethereum_timestamp = 1;
+}
+
+message EthereumGetBlockTimeInput {
+    primitives.timestamp_nano reference_timestamp = 1;
+}
+
+message EthereumGetBlockTimeOutput {
+    primitives.timestamp_nano ethereum_timestamp = 1;
+}
+
+message EthereumGetBlockNumberByTimeInput {
+    primitives.timestamp_nano reference_timestamp = 1;
+    primitives.timestamp_nano ethereum_timestamp = 2;
+}
+
+message EthereumGetBlockNumberByTimeOutput {
     uint64 ethereum_block_number = 1;
 }

--- a/types/go/services/crosschain_connector.mb.go
+++ b/types/go/services/crosschain_connector.mb.go
@@ -14,6 +14,9 @@ type CrosschainConnector interface {
 	EthereumCallContract(ctx context.Context, input *EthereumCallContractInput) (*EthereumCallContractOutput, error)
 	EthereumGetTransactionLogs(ctx context.Context, input *EthereumGetTransactionLogsInput) (*EthereumGetTransactionLogsOutput, error)
 	EthereumGetBlockNumber(ctx context.Context, input *EthereumGetBlockNumberInput) (*EthereumGetBlockNumberOutput, error)
+	EthereumGetBlockTime(ctx context.Context, input *EthereumGetBlockTimeInput) (*EthereumGetBlockTimeOutput, error)
+	EthereumGetBlockTimeByNumber(ctx context.Context, input *EthereumGetBlockTimeByNumberInput) (*EthereumGetBlockTimeByNumberOutput, error)
+	EthereumGetBlockNumberByTime(ctx context.Context, input *EthereumGetBlockNumberByTimeInput) (*EthereumGetBlockNumberByTimeOutput, error)
 }
 
 /////////////////////////////////////////////////////////////////////////////
@@ -196,6 +199,132 @@ func (x *EthereumGetBlockNumberOutput) String() string {
 }
 
 func (x *EthereumGetBlockNumberOutput) StringEthereumBlockNumber() (res string) {
+	res = fmt.Sprintf("%x", x.EthereumBlockNumber)
+	return
+}
+
+/////////////////////////////////////////////////////////////////////////////
+// message EthereumGetBlockTimeByNumberInput (non serializable)
+
+type EthereumGetBlockTimeByNumberInput struct {
+	ReferenceTimestamp  primitives.TimestampNano
+	EthereumBlockNumber uint64
+}
+
+func (x *EthereumGetBlockTimeByNumberInput) String() string {
+	if x == nil {
+		return "<nil>"
+	}
+	return fmt.Sprintf("{ReferenceTimestamp:%s,EthereumBlockNumber:%s,}", x.StringReferenceTimestamp(), x.StringEthereumBlockNumber())
+}
+
+func (x *EthereumGetBlockTimeByNumberInput) StringReferenceTimestamp() (res string) {
+	res = fmt.Sprintf("%s", x.ReferenceTimestamp)
+	return
+}
+
+func (x *EthereumGetBlockTimeByNumberInput) StringEthereumBlockNumber() (res string) {
+	res = fmt.Sprintf("%x", x.EthereumBlockNumber)
+	return
+}
+
+/////////////////////////////////////////////////////////////////////////////
+// message EthereumGetBlockTimeByNumberOutput (non serializable)
+
+type EthereumGetBlockTimeByNumberOutput struct {
+	EthereumTimestamp primitives.TimestampNano
+}
+
+func (x *EthereumGetBlockTimeByNumberOutput) String() string {
+	if x == nil {
+		return "<nil>"
+	}
+	return fmt.Sprintf("{EthereumTimestamp:%s,}", x.StringEthereumTimestamp())
+}
+
+func (x *EthereumGetBlockTimeByNumberOutput) StringEthereumTimestamp() (res string) {
+	res = fmt.Sprintf("%s", x.EthereumTimestamp)
+	return
+}
+
+/////////////////////////////////////////////////////////////////////////////
+// message EthereumGetBlockTimeInput (non serializable)
+
+type EthereumGetBlockTimeInput struct {
+	ReferenceTimestamp primitives.TimestampNano
+}
+
+func (x *EthereumGetBlockTimeInput) String() string {
+	if x == nil {
+		return "<nil>"
+	}
+	return fmt.Sprintf("{ReferenceTimestamp:%s,}", x.StringReferenceTimestamp())
+}
+
+func (x *EthereumGetBlockTimeInput) StringReferenceTimestamp() (res string) {
+	res = fmt.Sprintf("%s", x.ReferenceTimestamp)
+	return
+}
+
+/////////////////////////////////////////////////////////////////////////////
+// message EthereumGetBlockTimeOutput (non serializable)
+
+type EthereumGetBlockTimeOutput struct {
+	EthereumTimestamp primitives.TimestampNano
+}
+
+func (x *EthereumGetBlockTimeOutput) String() string {
+	if x == nil {
+		return "<nil>"
+	}
+	return fmt.Sprintf("{EthereumTimestamp:%s,}", x.StringEthereumTimestamp())
+}
+
+func (x *EthereumGetBlockTimeOutput) StringEthereumTimestamp() (res string) {
+	res = fmt.Sprintf("%s", x.EthereumTimestamp)
+	return
+}
+
+/////////////////////////////////////////////////////////////////////////////
+// message EthereumGetBlockNumberByTimeInput (non serializable)
+
+type EthereumGetBlockNumberByTimeInput struct {
+	ReferenceTimestamp primitives.TimestampNano
+	EthereumTimestamp  primitives.TimestampNano
+}
+
+func (x *EthereumGetBlockNumberByTimeInput) String() string {
+	if x == nil {
+		return "<nil>"
+	}
+	return fmt.Sprintf("{ReferenceTimestamp:%s,EthereumTimestamp:%s,}", x.StringReferenceTimestamp(), x.StringEthereumTimestamp())
+}
+
+func (x *EthereumGetBlockNumberByTimeInput) StringReferenceTimestamp() (res string) {
+	res = fmt.Sprintf("%s", x.ReferenceTimestamp)
+	return
+}
+
+func (x *EthereumGetBlockNumberByTimeInput) StringEthereumTimestamp() (res string) {
+	res = fmt.Sprintf("%s", x.EthereumTimestamp)
+	return
+}
+
+/////////////////////////////////////////////////////////////////////////////
+// message EthereumGetBlockNumberByTimeOutput (non serializable)
+
+type EthereumGetBlockNumberByTimeOutput struct {
+	EthereumBlockNumber uint64
+}
+
+func (x *EthereumGetBlockNumberByTimeOutput) String() string {
+	if x == nil {
+		return "<nil>"
+	}
+	return fmt.Sprintf("{EthereumBlockNumber:%s,}", x.StringEthereumBlockNumber())
+}
+
+func (x *EthereumGetBlockNumberByTimeOutput) StringEthereumBlockNumber() (res string) {
 	res = fmt.Sprintf("%x", x.EthereumBlockNumber)
 	return
 }

--- a/types/go/services/crosschain_connector_mock.mb.go
+++ b/types/go/services/crosschain_connector_mock.mb.go
@@ -39,3 +39,30 @@ func (s *MockCrosschainConnector) EthereumGetBlockNumber(ctx context.Context, in
 		return nil, ret.Error(1)
 	}
 }
+
+func (s *MockCrosschainConnector) EthereumGetBlockTime(ctx context.Context, input *EthereumGetBlockTimeInput) (*EthereumGetBlockTimeOutput, error) {
+	ret := s.Called(ctx, input)
+	if out := ret.Get(0); out != nil {
+		return out.(*EthereumGetBlockTimeOutput), ret.Error(1)
+	} else {
+		return nil, ret.Error(1)
+	}
+}
+
+func (s *MockCrosschainConnector) EthereumGetBlockTimeByNumber(ctx context.Context, input *EthereumGetBlockTimeByNumberInput) (*EthereumGetBlockTimeByNumberOutput, error) {
+	ret := s.Called(ctx, input)
+	if out := ret.Get(0); out != nil {
+		return out.(*EthereumGetBlockTimeByNumberOutput), ret.Error(1)
+	} else {
+		return nil, ret.Error(1)
+	}
+}
+
+func (s *MockCrosschainConnector) EthereumGetBlockNumberByTime(ctx context.Context, input *EthereumGetBlockNumberByTimeInput) (*EthereumGetBlockNumberByTimeOutput, error) {
+	ret := s.Called(ctx, input)
+	if out := ret.Get(0); out != nil {
+		return out.(*EthereumGetBlockNumberByTimeOutput), ret.Error(1)
+	} else {
+		return nil, ret.Error(1)
+	}
+}


### PR DESCRIPTION
## Description

Change of the election schedule to be based on time instead of Ethereum blocks to provide a more consistent and easy to understand schedule.
Election schedule - every 3 days based on the Ethereum block time to enable external auditing
Vote validity - up to 1 week

## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
