### PR TITLE
[WIP] Add more methods to _Deployments contract allowing for multiple versions

### DIFF
--- a/behaviors/smart-contracts/system/_Deployments.md
+++ b/behaviors/smart-contracts/system/_Deployments.md
@@ -35,6 +35,8 @@ To retrieve the code, `getCodeParts()` in combination with `getCodePart()` shoul
 &nbsp;
 ## `deployService` (method)
 
+Deploys the smart contract for the first time.
+
 #### Permissions
 * `External` (caller can be anyone).
 * `ReadWrite` (potentially changes state).
@@ -42,12 +44,31 @@ To retrieve the code, `getCodeParts()` in combination with `getCodePart()` shoul
 #### Behavior
 * Takes service name, processor type and code as arguments.
 * Has ellipsis syntax, meaning that additional code can be passed as an argument: `deployService(serviceName, processorType, code1, code2, code3, code4)`
-* Make sure the service isn't already deployed by calling `getInfo`.
+* Make sure the **service isn't already deployed** by calling `getInfo`.
 * Write processor type to state under key `<name>.Processor` by calling `State.WriteUint32ByKey`.
 * Write first part of the code to state under key `<name>.Code` by calling `State.WriteBytesByKey`.
 * Write other parts of the code to state under key `<name>.Code.<counter>` by calling `State.WriteBytesByKey`.
 * Every time code part is written into state, increment `<name>.CodeParts` counter (except the first time for backwards compatibility)
 * Init the service by calling `Service.CallMethod` with method `_init`.
+  * This is an `Internal` method, requires `System` permissions.
+
+## `deployVersion` (method)
+
+Deploys new version of already deployed smart contract.
+
+#### Permissions
+* `External` (caller can be anyone).
+* `ReadWrite` (potentially changes state).
+
+#### Behavior
+* Takes service name, processor type and code as arguments.
+* Has ellipsis syntax, meaning that additional code can be passed as an argument: `deployService(serviceName, processorType, code1, code2, code3, code4)`
+* Make sure the **service is already deployed** by calling `getInfo`.
+* Write processor type to state under key `<name>.Processor.Version.<version>` by calling `State.WriteUint32ByKey`.
+* Write first part of the code to state under key `<name>.Code.<version>` by calling `State.WriteBytesByKey`.
+* Write other parts of the code to state under key `<name>.Code.<counter>.Version.<version>` by calling `State.WriteBytesByKey`.
+* Every time code part is written into state, increment `<name>.CodeParts.<version>` counter (except the first time for backwards compatibility)
+* Increments `<name>.Version` value by calling `State.WriteUint32ByKey`.
   * This is an `Internal` method, requires `System` permissions.
 
 &nbsp;
@@ -69,6 +90,7 @@ To retrieve the code, `getCodeParts()` in combination with `getCodePart()` shoul
 
 #### Behavior
 * Takes service name as argument.
+* Takes version as optional argument (if not present defaults to `0`)
 * Read code from state key `<name>.CodeParts` by calling `State.ReadBytesByKey`, increments in by `1`.
 * Returns error if the contract was not deployed
 
@@ -81,5 +103,41 @@ To retrieve the code, `getCodeParts()` in combination with `getCodePart()` shoul
 #### Behavior
 * Takes service name as argument.
 * Takes index as argument.
+* Takes version as optional argument (if not present defaults to `0`)
 * Read code from state key `<name>.Code.<counter>` by calling `State.ReadBytesByKey`.
 * Returns error if the contract was not deployed
+
+## `getVersion` (method)
+
+Returns current version of the contract (`0` for a contract deployed with `deployService`).
+
+#### Permissions
+* `External` (caller can be anyone).
+* `ReadOnly` (does not change state).
+
+#### Behavior
+* Takes service name as argument.
+* Read code from state key `<name>.Code.<counter>` by calling `State.ReadUint32ByKey`.
+* Returns `0` if the contract was not deployed
+
+## `allowVersioning` (method)
+
+Owner only.
+
+Allows new versions of the contract to be uploaded.
+
+## `disallowVersioning` (method)
+
+Owner only.
+
+Disallows new versions of the contract to be uploaded.
+
+## `tranferOwnership` (method)
+
+Owner only.
+
+Transfers ownership to the new owner. Unless ownership is accepted, the old owner still retains full ownership of the contract.
+
+## `acceptOwnership` (method)
+
+New owner can accept or reject the ownership of the contract.


### PR DESCRIPTION
Proposed new methods:

```
deployVersion() // called after deployService
getVersion() // returns latest version number

allowVersioning()
disallowVersioning()

transferOwnership()
acceptOwnership()
```

In this model there is no way to completely remove versioning that might be a bit tricky.

Also, there is no migration method in the contract, which also might be problematic.

**This PR is a preparation for brainstorming meeting with OdedW**